### PR TITLE
Delete duplicate KeyGrave

### DIFF
--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -375,7 +375,6 @@ aliases = Q.mkMultiMap
   , (KeyRightMeta,      ["rmeta", "rmet"])
   , (KeyBackspace,      ["bks", "bspc"])
   , (KeyCapsLock,       ["caps"])
-  , (KeyGrave,          ["grv"])
   , (Key102nd,          ["102d", "lsgt", "nubs"])
   , (KeyForward,        ["fwd"])
   , (KeyScrollLock,     ["scrlck", "slck"])


### PR DESCRIPTION
`KeyGrave` is defined twice (see 12 lines below).