### PR TITLE
implemented tap-macro-release

### DIFF
--- a/src/KMonad/App/Parser/TokenJoiner.hs
+++ b/src/KMonad/App/Parser/TokenJoiner.hs
@@ -352,8 +352,8 @@ joinButton ns als =
     -- Various compound buttons
     KComposeSeq bs     -> view cmpKey >>= \c -> jst $ tapMacro . (c:) <$> mapM go bs
     KTapMacro bs       -> jst $ tapMacro           <$> mapM go bs
-    KTapMacroRelease bs
-      -> jst $ tapMacroRelease            <$> mapM go bs
+    KTapMacroRelease bs ->
+      jst $ tapMacroRelease            <$> mapM go bs
     KAround o i        -> jst $ around             <$> go o <*> go i
     KTapNext t h       -> jst $ tapNext            <$> go t <*> go h
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h

--- a/src/KMonad/App/Parser/TokenJoiner.hs
+++ b/src/KMonad/App/Parser/TokenJoiner.hs
@@ -352,6 +352,8 @@ joinButton ns als =
     -- Various compound buttons
     KComposeSeq bs     -> view cmpKey >>= \c -> jst $ tapMacro . (c:) <$> mapM go bs
     KTapMacro bs       -> jst $ tapMacro           <$> mapM go bs
+    KTapMacroRelease bs
+      -> jst $ tapMacroRelease            <$> mapM go bs
     KAround o i        -> jst $ around             <$> go o <*> go i
     KTapNext t h       -> jst $ tapNext            <$> go t <*> go h
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h

--- a/src/KMonad/App/Parser/Tokenizer.hs
+++ b/src/KMonad/App/Parser/Tokenizer.hs
@@ -276,6 +276,7 @@ keywordButtons =
   , ("layer-next"     , KLayerNext   <$> lexeme word)
   , ("around-next"    , KAroundNext  <$> buttonP)
   , ("tap-macro"      , KTapMacro    <$> some buttonP)
+  , ("tap-macro-release"      , KTapMacroRelease    <$> some buttonP)
   , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> numP)
   , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)

--- a/src/KMonad/App/Parser/Types.hs
+++ b/src/KMonad/App/Parser/Types.hs
@@ -88,6 +88,7 @@ data DefButton
   | KMultiTap [(Int, DefButton)] DefButton -- ^ Do things depending on tap-count
   | KAround DefButton DefButton            -- ^ Wrap 1 button around another
   | KTapMacro [DefButton]                  -- ^ Sequence of buttons to tap
+  | KTapMacroRelease [DefButton]                  -- ^ Sequence of buttons to tap
   | KComposeSeq [DefButton]                -- ^ Compose-key sequence
   | KPause Milliseconds                    -- ^ Pause for a period of time
   | KLayerDelay Int LayerTag               -- ^ Switch to a layer for a period of time

--- a/src/KMonad/App/Parser/Types.hs
+++ b/src/KMonad/App/Parser/Types.hs
@@ -88,7 +88,7 @@ data DefButton
   | KMultiTap [(Int, DefButton)] DefButton -- ^ Do things depending on tap-count
   | KAround DefButton DefButton            -- ^ Wrap 1 button around another
   | KTapMacro [DefButton]                  -- ^ Sequence of buttons to tap
-  | KTapMacroRelease [DefButton]                  -- ^ Sequence of buttons to tap
+  | KTapMacroRelease [DefButton]           -- ^ Sequence of buttons to tap, tap the last when released
   | KComposeSeq [DefButton]                -- ^ Compose-key sequence
   | KPause Milliseconds                    -- ^ Pause for a period of time
   | KLayerDelay Int LayerTag               -- ^ Switch to a layer for a period of time

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -364,8 +364,8 @@ joinButton ns als =
                              c   <- view cmpKey
                              jst $ tapMacro . (c:) <$> isps bs csd
     KTapMacro bs mbD   -> jst $ tapMacro           <$> isps bs mbD
-    KTapMacroRelease bs mbD
-      -> jst $ tapMacroRelease           <$> isps bs mbD
+    KTapMacroRelease bs mbD ->
+      jst $ tapMacroRelease           <$> isps bs mbD
     KAround o i        -> jst $ around             <$> go o <*> go i
     KTapNext t h       -> jst $ tapNext            <$> go t <*> go h
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -364,6 +364,8 @@ joinButton ns als =
                              c   <- view cmpKey
                              jst $ tapMacro . (c:) <$> isps bs csd
     KTapMacro bs mbD   -> jst $ tapMacro           <$> isps bs mbD
+    KTapMacroRelease bs mbD
+      -> jst $ tapMacroRelease           <$> isps bs mbD
     KAround o i        -> jst $ around             <$> go o <*> go i
     KTapNext t h       -> jst $ tapNext            <$> go t <*> go h
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -282,6 +282,8 @@ keywordButtons =
   , ("around-next"    , KAroundNext  <$> buttonP)
   , ("tap-macro"
     , KTapMacro <$> lexeme (some buttonP) <*> optional (keywordP "delay" numP))
+  , ("tap-macro-release"
+    , KTapMacroRelease <$> lexeme (some buttonP) <*> optional (keywordP "delay" numP))
   , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> numP)
   , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -92,6 +92,7 @@ data DefButton
   | KMultiTap [(Int, DefButton)] DefButton -- ^ Do things depending on tap-count
   | KAround DefButton DefButton            -- ^ Wrap 1 button around another
   | KTapMacro [DefButton] (Maybe Int)
+  | KTapMacroRelease [DefButton] (Maybe Int)
     -- ^ Sequence of buttons to tap, possible delay between each press
   | KComposeSeq [DefButton]                -- ^ Compose-key sequence
   | KPause Milliseconds                    -- ^ Pause for a period of time

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -92,8 +92,9 @@ data DefButton
   | KMultiTap [(Int, DefButton)] DefButton -- ^ Do things depending on tap-count
   | KAround DefButton DefButton            -- ^ Wrap 1 button around another
   | KTapMacro [DefButton] (Maybe Int)
-  | KTapMacroRelease [DefButton] (Maybe Int)
     -- ^ Sequence of buttons to tap, possible delay between each press
+  | KTapMacroRelease [DefButton] (Maybe Int)
+    -- ^ Sequence of buttons to tap, tap last on release, possible delay between each press
   | KComposeSeq [DefButton]                -- ^ Compose-key sequence
   | KPause Milliseconds                    -- ^ Pause for a period of time
   | KLayerDelay Int LayerTag               -- ^ Switch to a layer for a period of time

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -361,7 +361,6 @@ tapMacro bs = onPress $ go bs
     go (b:[])  = press b
     go (b:rst) = tap b >> go rst
 
-
 -- | Create a 'Button' that performs a series of taps on press,
 -- except for the last Button, which is tapped on release.
 tapMacroRelease :: [Button] -> Button

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -47,6 +47,7 @@ module KMonad.Model.Button
   , tapNextRelease
   , tapHoldNextRelease
   , tapMacro
+  , tapMacroRelease
   , stickyKey
   )
 where
@@ -86,6 +87,8 @@ mkButton a b = Button (Action a) (Action b)
 onPress :: AnyK () -> Button
 onPress p = mkButton p $ pure ()
 
+onRelease :: AnyK () -> Button
+onRelease p = mkButton (pure ()) p
 
 --------------------------------------------------------------------------------
 -- $running
@@ -358,6 +361,13 @@ tapMacro bs = onPress $ go bs
     go (b:[])  = press b
     go (b:rst) = tap b >> go rst
 
+
+tapMacroRelease :: [Button] -> Button
+tapMacroRelease bs = onPress $ go bs
+  where
+    go []      = pure ()
+    go (b:[])  = awaitMy Release $ tap b >> pure Catch
+    go (b:rst) = tap b >> go rst
 
 -- | Switch to a layer for a period of time, then automatically switch back
 layerDelay :: Milliseconds -> LayerTag -> Button

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -362,6 +362,8 @@ tapMacro bs = onPress $ go bs
     go (b:rst) = tap b >> go rst
 
 
+-- | Create a 'Button' that performs a series of taps on press,
+-- except for the last Button, which is tapped on release.
 tapMacroRelease :: [Button] -> Button
 tapMacroRelease bs = onPress $ go bs
   where


### PR DESCRIPTION
@6gk wanted a feature that allows him to tap a button on keypress and another on keyrelease. So i made a small patch for him with a new button called `tap-macro-release` which works just like `tap-macro`, but in contrast it taps the last button on keyrelease. I don't know if this is actually needed in kmonad or if it wouldn't bloat it, but i'll just drop the patch off.