### PR TITLE
Add note about Vim editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Want to add your own keyboard configuration to `./keymap`? Fork KMonad, create a
 
 ### Editor Support for the Configuration Language
 - [Emacs](https://github.com/slotThe/kbd-mode)
+- [Vim](https://github.com/kmonad/kmonad-vim)
 
 ### Startup
 There are startup scripts available for different init systems in


### PR DESCRIPTION
This exists in the organisation but wasn't documented in the README.

See also #69.