### PR TITLE
Add `Not available under this OS` error documentation to `faq.md` under General

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -160,3 +160,16 @@ creating a numpad in the middle of the laptop keyboard. This remapping happens
 in the hardware, before any event is ever registered with the operating system,
 therefore KMonad has no way to 'get' at any of those events. This means that we
 cannot remap them in any way.
+
+### Q: When I run KMonad I get error `Not available under this OS`
+
+A: This error occurs when there are OS-specific options in the used configuration
+file. Usually this happens when you are on windows, try to run the tutorial
+file and do not comment out or delete the Linux options in `defcfg` and
+uncomment the Windows options. Nevertheless, this still can happen on other
+operating systems, the error message changes slightly based on the operating
+system (e.g. `Not available under this OS: LowLevelHookSource`, `Not available
+under this OS: DeviceSource`), but they all start with `Not available under
+this OS` and all have the same solution.
+
+TL;DR: Make sure the options in `defcfg` are for your operating system.


### PR DESCRIPTION
Hello,

Since I thought that this is a simple piece of documentation, I worked on it. It closes the comment [#282 (comment)](https://github.com/kmonad/kmonad/issues/282#issuecomment-863001153). I think this is just a good starting point. It should be rewritten or modified later though.

Thanks for the time.