### PR TITLE
Fix the NixOS SystemD service

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -86,6 +86,7 @@ with lib;
             description = "KMonad Instance for: " +conf-name;
             serviceConfig = {
               Type = "simple";
+              Restart = "always";
               ExecStart =
                 "${cfg.package}/bin/kmonad ${kbd-path}" +
                   # kmonad will error on initialization for any unplugged keyboards


### PR DESCRIPTION
Add a delay before the service starts to ensure that all connected keyboards are initialized by the system