### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM haskell:9-buster
+
+WORKDIR /usr/src/kmonad/
+
+COPY ./stack.yaml /usr/src/kmonad/
+COPY ./kmonad.cabal /usr/src/kmonad/
+RUN stack setup
+
+COPY ./ /usr/src/kmonad/
+RUN stack build
+
+RUN \
+  stack install && \
+  chmod --verbose +x /root/.local/bin/kmonad

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -4,6 +4,7 @@ Jump to
 - [Compilation](installation.md#compilation)
   - [Using nix](installation.md#using-nix)
   - [Using stack](installation.md#using-stack)
+  - [Using Docker](installation.md#using-docker)
   - [Windows environment](installation.md#windows-environment)
   - [macOS](installation.md#macos)
 - [Binaries](installation.md#binaries)
@@ -28,6 +29,32 @@ If you would like `stack` to automatically copy the binary to a folder on your
 `$PATH`, you can use:
 ```shell
 stack install # Builds *and* copies
+```
+
+### Using Docker
+If you have Docker installed, you can build `kmonad` from source without the need to install anything else on your system, since the build container will always have all the needed build tools and dependencies (currently Haskell 9 on Debian Buster).
+This is very convenient if no binaries are available and you want to try some other branch, you don't want to install build tools or they're not available for your OS, etc. You can even use the provided `Dockerfile` for development testing. As of now, the built image is not meant to *run* `kmonad`, just to build it.
+
+Just do this from the `Dockerfile` directory:
+``` shell
+# Build the Docker image which will contain the binary.
+docker build -t kmonad-builder .
+
+# Spin up an ephemeral Docker container from the built image, to just copy the
+# built binary to the host's current directory bind-mounted inside the
+# container at /host/.
+docker run --rm -it -v ${PWD}:/host/ kmonad-builder bash -c 'cp -vp /root/.local/bin/kmonad /host/'
+
+# Clean up build image, since it is no longer needed.
+docker rmi kmonad-builder
+```
+You will find a `kmonad` binary in your current directory.
+
+As an added bonus, with recent Docker versions you can build images straight
+from public repo URLs, whithout even needing to clone the repo.
+Do this as the build step (the first one) in the previous instructions:
+``` shell
+docker build -t kmonad-builder github.com/kmonad/kmonad.git
 ```
 
 ### Using `nix`


### PR DESCRIPTION
I just discovered KMonad and found it awesome. Thank you very much for sharing this fine piece of software.

Since I wanted to try the latest master branch, I had to go for building. I'm on Ubuntu Bionic and I didn't feel like to install more software just to build it. So I went for building under Docker. I've created a `Dockerfile` based on Haskell 9 on Debian Buster which just adds source files and runs build instructions.

With just this file, I've been able to get a binary freshly built from source by just doing this in the `Dockerfile` directory:
``` shell
# Build a Docker image which will contain the binary.
$ docker build -t kmonad-builder .
# Spin up a Docker container from the built image, which will copy the
# built binary to a directory bind-mounted to the host's current dir.
$ docker run --rm -it -v ${PWD}:/host/ kmonad-builder bash -c 'cp -vp /root/.local/bin/kmonad /host/'
# Clean up build image.
$ docker rmi kmonad-builder
```
And... ta-da! I found in my current dir a `kmonad` binary ready to use (actually, I'm using this since a couple days ago without problems, so far). It builds also on your `keycode-refactor` branch, but I've not used that binary.

As an added bonus, you can build Docker images directly from public repo URLs, whithout even needing to clone (mine used as example here, in case you want to copy/paste for testing):

``` shell
$ docker build -t kmonad-builder github.com/pataquets/kmonad.git
```

Now, about the image:
First and foremost, since I was struggling to find an up-to-date binary for my system and I was able to get it easily using Docker, as I do with other software, I wanted to share it in case it can be of any help to others. You only need Docker installed, since the build happens isolated with all the build toolchain already installed in the building container. No other software needed in the host. This is way easier, tidier and safer than having to install build deps and build on your system. Looks like the built artifacts availability of the project could benefit of some love.

This `Dockerfile` can even be used in a hack/build/test development workflow (it's optimized to take the most advantage possible of Docker's build cache).

It also might come handy later when you get to do some CI, as I've seen in #264.

Otherwise, as it is now, it does not fits the 'use Docker to run the app' use-case as it's usually done in Docker. Hooking into host's uinput/udev/etc from inside a Docker container would be a first for me to sort out (I've accomplished using host's FUSE and disk/audio devices from Docker containers in the past, thou). Also, the built artifact weighs 3.85 Gb (!), but this can be solved, if necessary. But anyway, I feel it is a useful enough tool worth contributing, and also my way of giving back to this awesome software. I would be more than happy to submit a documentation PR, once we sort out if this is OK.

I can be of any further help, do not hesitate to ask. I wish you all the best of health.