### PR TITLE
Add `--version` (`-V`) flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Added macOS 11.0 support
 - Added a `sticky-key`
 - Expanded documentation
+- Added `--version` (`-V`) flag
 
 ### [Changed]
 - Reorganized codebase

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -47,6 +47,7 @@ library
     , rio
     , time
     , unliftio
+    , template-haskell
   default-extensions:
       ConstraintKinds
       DeriveFunctor
@@ -82,6 +83,7 @@ library
       KMonad.Args.Cmd
       KMonad.Args.Parser
       KMonad.Args.Joiner
+      KMonad.Args.TH
       KMonad.Args.Types
       KMonad.Keyboard
       KMonad.Keyboard.ComposeSeq
@@ -93,6 +95,7 @@ library
       KMonad.Util
       KMonad.Util.LayerStack
       KMonad.Util.MultiMap
+      Paths_kmonad
 
   if os(linux)
     exposed-modules:

--- a/src/KMonad/Args/TH.hs
+++ b/src/KMonad/Args/TH.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE BlockArguments #-}
+{-|
+Module      : KMonad.Args.TH
+Description : Template Haskell to use in the CLI
+Copyright   : (c) slotThe, 2021
+License     : MIT
+
+Maintainer  : soliditsallgood@mailbox.org
+Stability   : experimental
+Portability : non-portable (TH)
+
+-}
+module KMonad.Args.TH (gitHash) where
+
+import KMonad.Prelude
+
+import Language.Haskell.TH (Exp, Q)
+import Language.Haskell.TH.Syntax (runIO)
+import UnliftIO.Process (readProcessWithExitCode)
+
+
+-- | Get the git hash of the current revision at compile time
+gitHash :: Q Exp
+gitHash = do
+  str <- runIO do
+    (exitCode, hash, _) <- readProcessWithExitCode "git" ["rev-parse", "HEAD"] ""
+    pure case exitCode of
+      ExitSuccess -> takeWhile (/= '\n') hash
+      _           -> ""
+  [| fromString str |]


### PR DESCRIPTION
Adds a --version (-V) flag to the CLI.  It prints the current version as
noted in the cabal file, as well as (if possible) a hash of the revision
that kmonad was compiled with.  The bulk of the changes are just the
overhead of creating a new module for TemplateHaskell (GHC does not like
local definitions of this stuff).  Requires `git` to be in $PATH, though
is seems like a reasonable assumption.

Fixes: https://github.com/kmonad/kmonad/issues/296

@pataquets would you care to give this a try?