### PR TITLE
Remove inconsistencies between a normal service and a NixOS one

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -87,6 +87,8 @@ with lib;
             serviceConfig = {
               Type = "simple";
               Restart = "always";
+              RestartSec = 3;
+              Nice = -20;
               ExecStart =
                 "${cfg.package}/bin/kmonad ${kbd-path}" +
                   # kmonad will error on initialization for any unplugged keyboards


### PR DESCRIPTION
Kmonad systemd modules previously had an opition `Restart=always`. It was doing literally that - restarting the service every several seconds, even if it didn't produce any errors. This PR changes it to `Restart=on-failure`, so that the service only restarts in case it fails.