### PR TITLE
Cancel multi-tap when another key is pressed (closes #304)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ### [Changed]
 - Reorganized codebase
+- The `multi-tap` key now immediately taps the current key when another
+  key is pressed during tapping.
 
 ### [Fixed]
 - Fixed compilation error under Mac, having to do with typo in Keycodes

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -789,7 +789,8 @@
   without delay. As long as you tap the `multi-tap` within the delay specified,
   it will jump to the next button. Once the delay is exceeded the selected
   button is pressed. If the last button in the list is reached, it is
-  immediately pressed.
+  immediately pressed. When another key is pressed down while we're tapping,
+  `multi-tap' also immediately exits and taps the current button.
 
   Note that you can actually hold the button, so in the below example, going:
   tap-tap-hold (wait 300ms) will get you a pressed c, until you release again.


### PR DESCRIPTION
This PR will close #304. It changes the logic of multi-tap such that pressing another key while still in the multi-tap delay cancels the delay and just taps the current button of the multi-tap sequence, as described in #304.

There is still some issue with modifier keys: assuming `c` is the first symbol of the multitap sequence and I want to do `lctl+c`, it will not work when I release `lctl` before the delay.
(Probably this event was already eaten by the event manager associated to `lctl`.)

Any idea how to improve this?

(also this is my first Haskell code ever, please be gentle but I will gladly listen to constructive criticisms!)