### PR TITLE
Add missing nix dependency

### DIFF
--- a/nix/kmonad.nix
+++ b/nix/kmonad.nix
@@ -1,6 +1,6 @@
 { mkDerivation, base, cereal, lens, megaparsec, mtl
 , optparse-applicative, resourcet, rio, stdenv, time, unix
-, unliftio
+, unliftio, pkgs
 }:
 mkDerivation {
   pname = "kmonad";
@@ -12,6 +12,7 @@ mkDerivation {
     base cereal lens megaparsec mtl optparse-applicative resourcet rio
     time unix unliftio
   ];
+  buildDepends = [ pkgs.git ];
   executableHaskellDepends = [ base ];
   doHaddock = false;
   description = "Advanced keyboard remapping utility";


### PR DESCRIPTION
#301 added a git requirement to the build which is not available in the nix build environment. This fix is still probably not ideal as it results in an empty commit hash, but at least it fixes the build.