### PR TITLE
JNSF, JNRF and FNRS layouts

### DIFF
--- a/keymap/user/gkbd/README.md
+++ b/keymap/user/gkbd/README.md
@@ -1,0 +1,7 @@
+# JNSF, JNRF and FNRS layouts
+
+Configurations for the following layouts:
+
+ * [JNSF layout](https://lykt.xyz/jnsf/)
+ * [JNRF layout](https://lykt.xyz/jnsf/retro/)
+ * [FNRS layout](https://lykt.xyz/jnsf/5/)

--- a/keymap/user/gkbd/fnrs.kbd
+++ b/keymap/user/gkbd/fnrs.kbd
@@ -1,0 +1,31 @@
+(defcfg
+  ;; ** For Linux **
+  input  (device-file "/dev/input/by-id/usb-USB_KEYBOARD-event-kbd")
+  output (uinput-sink "KMonad output")
+
+  ;; ** For Windows **
+  ;; input  (low-level-hook)
+  ;; output (send-event-sink)
+
+  ;; ** For MacOS **
+  ;; input  (iokit-name "my-keyboard-product-string")
+  ;; output (kext)
+
+  fallthrough true
+)
+
+(defsrc
+  q w e r t y u i o p
+  a s d f g h j k l ;
+  z x c v b n m
+  KeyHangeul
+  KeyHanja
+)
+
+(deflayer jnrf
+  q x u h p m c l k ;
+  o a e f n r s t i d
+  z j y b v w g
+  bks
+  del
+)

--- a/keymap/user/gkbd/jnrf.kbd
+++ b/keymap/user/gkbd/jnrf.kbd
@@ -1,0 +1,27 @@
+(defcfg
+  ;; ** For Linux **
+  input  (device-file "/dev/input/by-id/usb-USB_KEYBOARD-event-kbd")
+  output (uinput-sink "KMonad output")
+
+  ;; ** For Windows **
+  ;; input  (low-level-hook)
+  ;; output (send-event-sink)
+
+  ;; ** For MacOS **
+  ;; input  (iokit-name "my-keyboard-product-string")
+  ;; output (kext)
+
+  fallthrough true
+)
+
+(defsrc
+  q w e r t y u i o p
+  a s d f g h j k l ;
+  z x c v b n m , . / lsgt
+)
+
+(deflayer jnrf
+  , . bks l h w s c y k
+  o a e j n r f t i d
+  / x u b v m g p q z ;
+)

--- a/keymap/user/gkbd/jnsf.kbd
+++ b/keymap/user/gkbd/jnsf.kbd
@@ -1,0 +1,31 @@
+(defcfg
+  ;; ** For Linux **
+  input  (device-file "/dev/input/by-id/usb-USB_KEYBOARD-event-kbd")
+  output (uinput-sink "KMonad output")
+
+  ;; ** For Windows **
+  ;; input  (low-level-hook)
+  ;; output (send-event-sink)
+
+  ;; ** For MacOS **
+  ;; input  (iokit-name "my-keyboard-product-string")
+  ;; output (kext)
+
+  fallthrough true
+)
+
+(defsrc
+  q w e r t y u i o p
+  a s d f g h j k l ;
+  z x c v b n m
+  KeyHangeul
+  KeyHanja
+)
+
+(deflayer jnrf
+  q k u r h m c l p ;
+  o a e j n s f t i d
+  z x y b v w g
+  bks
+  del
+)


### PR DESCRIPTION
User configurations for JNSF, JNRF and FNRS layouts.

Other resources are available at https://gitlab.com/lykt/jnsf