### PR TITLE
Fix doc for user getting started.

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -23,34 +23,35 @@
 
 ### Q: How do I get Uinput permissions?
 
-A: In Linux KMonad needs to be able to access the uinput subsystem to inject
+A: In Linux KMonad needs to be able to access the `input` and `uinput` subsystem to inject
 events. To do this, your user needs to have permissions. To achieve this, take
 the following steps:
 
-If the `uinput` group does not exist, check whether your system has an `input`
-group and try adding your user to that one instead. If this does not work,
-create a new group with:
+If the `uinput` group does not exist, create a new group with:
 
-1. Make sure the 'uinput' group exists
+1. Make sure the `uinput` group exists
 
 ``` shell
 sudo groupadd uinput
 ```
 
-2. Add your user to the 'uinput' group:
+2. Add your user to the `input` and the `uinput` group:
 ``` shell
+sudo usermod -aG input username
 sudo usermod -aG uinput username
 ```
 
+Make sure that it's effective by running `groups`. You might have to logout and login.
+
 3. Make sure the uinput device file has the right permissions:
-Add a udev rule (in either `/etc/dev/rules.d` or `/lib/udev/rules.d`) with the
+Add a udev rule (in either `/etc/udev/rules.d` or `/lib/udev/rules.d`) with the
 following content:
 ```shell
 KERNEL=="uinput", MODE="0660", GROUP="uinput", OPTIONS+="static_node=uinput"
 ```
 
 4. Make sure the `uinput` drivers are loaded.
-You will probably have to run this command whenever you start kmonad for the first time.
+You will probably have to run this command whenever you start `kmonad` for the first time.
 ``` shell
 sudo modprobe uinput
 ```
@@ -58,9 +59,10 @@ sudo modprobe uinput
 
 ### Q: How do I know which event-file corresponds to my keyboard?
 
-A: By far the best solution is to use the keyboard devices listed under
-`/dev/input/by-id`. If you can't figure out which file just by the filenames,
-the `evtest` program is very helpful.
+A: By far the best solution is to use the keyboard devices listed
+under `/dev/input/by-id`. In some case, you could also try
+`/dev/input/by-path`. If you can't figure out which file just by
+the filenames, the `evtest` program is very helpful.
 
 ### Q: How do I emit Hyper_L?
 


### PR DESCRIPTION
1. Fix typo.
2. `input` and `uinput` are both required.
3. `by-id` won't always work.