### PR TITLE
Update nix derivation

### DIFF
--- a/nix/kmonad.nix
+++ b/nix/kmonad.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, cereal, lens, megaparsec, mtl
-, optparse-applicative, resourcet, rio, stdenv, time, unix
+{ mkDerivation, base, cereal, lens, lib, megaparsec, mtl
+, optparse-applicative, resourcet, rio, time, unix
 , unliftio, pkgs
 }:
 mkDerivation {
@@ -16,5 +16,5 @@ mkDerivation {
   executableHaskellDepends = [ base ];
   doHaddock = false;
   description = "Advanced keyboard remapping utility";
-  license = stdenv.lib.licenses.mit;
+  license = lib.licenses.mit;
 }

--- a/nix/kmonad.nix
+++ b/nix/kmonad.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "kmonad";
-  version = "0.4";
+  version = "0.4.1";
   src = ./..;
   isLibrary = true;
   isExecutable = true;

--- a/nix/pinned-nixpkgs.nix
+++ b/nix/pinned-nixpkgs.nix
@@ -1,5 +1,4 @@
-builtins.fetchGit {
-  url = "https://github.com/NixOS/nixpkgs.git";
-  rev = "5b36111f3c7a0468d099516832418e4e350fde6c";
-  ref = "master";
+builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/5b36111f3c7a0468d099516832418e4e350fde6c.tar.gz";
+  sha256 = "1a8v85xaqp46ccfihpi20vwrb1bvqhpsfnasq8klg92qqwq9wiiy";
 }


### PR DESCRIPTION
This fixes a few things in the nix derivation.

- Update the version to the same latest tagged version
- Replace deprecated usage of stdenv.lib, the lib is the preferred input.
- Improve the speed of fetching pinned nixpkgs by using tarball instead.