### PR TITLE
Docker static build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.ghc*
+dist*
+.stack*
+configs*
+source_maps*
+stack.yaml.lock
+src_solid
+log.log
+tmp
+template/testing.kbd
+bin/
+result
+kmonad

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: image.tar
+          key: ${{ runner.os }}-primes
+
+      - run: |
+          [ -r image.tar ] && docker load -i image.tar || true
+          rm image.tar || true
+
+      - run: docker build . -t kmonad-builder --cache-from=kmonad-builder:latest
+
+      - run: docker run --rm -v ${PWD}:/host/ kmonad-builder bash -c 'cp -vp /root/.local/bin/kmonad /host/'
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: kmonad-binary
+          path: kmonad
+
+      - run: docker save kmonad-builder -o image.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM haskell:9-buster
+FROM lierdakil/alpine-haskell:8.10.4
 
 WORKDIR /usr/src/kmonad/
+RUN apk --no-cache add git
+RUN stack update
 
-COPY ./stack.yaml /usr/src/kmonad/
-COPY ./kmonad.cabal /usr/src/kmonad/
-RUN stack setup
-
-COPY ./ /usr/src/kmonad/
-RUN stack build
-
-RUN \
-  stack install && \
-  chmod --verbose +x /root/.local/bin/kmonad
+COPY ./kmonad.cabal ./
+COPY ./static/stack.yaml ./static/
+COPY ./stack.yaml ./
+RUN cat ./static/stack.yaml >> stack.yaml && \
+  stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies
+COPY ./ ./
+RUN cat ./static/stack.yaml >> stack.yaml && \
+  stack --no-install-ghc --system-ghc --skip-ghc-check install

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN cat ./static/stack.yaml >> stack.yaml && \
   stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies
 COPY ./ ./
 RUN cat ./static/stack.yaml >> stack.yaml && \
-  stack --no-install-ghc --system-ghc --skip-ghc-check install
+  stack --no-install-ghc --system-ghc --skip-ghc-check install --ghc-options -j

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -80,8 +80,7 @@ $(nix-build --no-link -A fullBuildScript)
 ### Using Docker
 If you have Docker installed, you can build `kmonad` from source without the
 need to install anything else on your system, since the build container will
-always have all the needed build tools and dependencies (currently Haskell 9 on
-Debian Buster).
+always have all the needed build tools and dependencies.
 
 This is very convenient if no binaries are available and you want to try some
 other branch, you don't want to install build tools or they're not available

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -150,7 +150,7 @@ The definition of a key chord then looks like this:
   `layer-next` but more generalized)
 
   ```clojure
-  (defalias ns  (around-next sft)  ;; Shift the next press
+  (defalias ns  (around-next sft))  ;; Shift the next press
   ```
 
 + `sticky keys`: act like the key is held temporarily after just one

--- a/static/stack.yaml
+++ b/static/stack.yaml
@@ -1,0 +1,2 @@
+ghc-options:
+  $everything: -optl-pthread -optl-static -fPIC -fasm -split-sections


### PR DESCRIPTION
As discussed in #335, this is a Dockerfile for building a static executable. Additionally, I've added a GitHub action that builds the executable and uploads it as an artefact. I've figured out how to convert it to use stack instead of cabal.

I'm using my own docker image as the base, but it's simply an Alpine image with some dependencies and GHC installed via ghcup, the sources are at https://github.com/lierdakil/alpine-haskell. Note that at the time of writing, stack can't install newer GHC versions on Alpine, so we have to go through ghcup (or build from source)

I did basically overwrite the original Buster-based Dockerfile, as I understood that to be the intention stated in #335. Besides, building a non-static executable in a Docker environment has questionable utility if it's meant to run on the host, unless the host matches the Docker environment pretty closely. However, we can also have two Dockerfiles if that's preferable.

I've also fixed a typo in the docs with https://github.com/kmonad/kmonad/commit/f35c8cee959c43a76e0278a28a02b8b6b99e544a -- I don't really want to create a separate PR for one-character patch.