### PR TITLE
Add Haskel CI workflow

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -81,7 +81,7 @@ jobs:
             --fast --no-terminal --skip-msys \
             --resolver=${{ matrix.resolver }} --system-ghc
 
-      - name: Build and test (macOS)
+      - name: Build and test (macOS, dext)
         shell: bash
         if: runner.os == 'macOS'
         run: |
@@ -90,3 +90,12 @@ jobs:
             --resolver=${{ matrix.resolver }} --system-ghc \
             --flag kmonad:dext \
             --extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit:c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
+
+      - name: Build and test (macOS, kext)
+        shell: bash
+        if: runner.os == 'macOS'
+        run: |
+          stack test \
+            --fast --no-terminal \
+            --resolver=${{ matrix.resolver }} --system-ghc \
+            --flag kmonad:kext --extra-include-dirs=c_src/mac/Karabiner-VirtualHIDDevice/dist/include

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -1,0 +1,84 @@
+name: Haskell CI - Stack based
+# note: for the most part, shamelessly stolen from xmonad
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Stack CI - ${{ matrix.os }} - ${{ matrix.resolver }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ startsWith( matrix.resolver, 'nightly-' ) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        resolver: [lts-16, lts-18, nightly-2021-08-21]
+
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+
+      - uses: haskell/actions/setup@v1
+        id: hs-setup
+        with:
+          ghc-version: ${{ fromJSON('{"lts-16":"8.8.4","lts-18":"8.10.4","nightly-2021-08-21":"9.0.1"}')[matrix.resolver] }}
+          enable-stack: true
+
+      - name: Refresh caches once a month
+        id: cache-date
+        # GHA writes caches on the first miss and then never updates them again;
+        # force updating the cache at least once a month
+        run: |
+          echo "::set-output name=date::$(date +%Y-%m)"
+
+      - name: Ensure STACK_ROOT exists on Windows
+        if: runner.os == 'Windows'
+        run: New-Item -ItemType directory -Path ${{ steps.hs-setup.outputs.stack-root }}
+
+      - name: Cache Haskell package metadata
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.hs-setup.outputs.stack-root }}/pantry
+          key: stack-pantry-${{ runner.os }}-${{ steps.cache-date.outputs.date }}
+          restore-keys: |
+            stack-pantry-${{ runner.os }}-
+
+      - name: Cache Haskell dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.hs-setup.outputs.stack-root }}/*
+            !${{ steps.hs-setup.outputs.stack-root }}/pantry
+          key: stack-${{ runner.os }}-${{ matrix.resolver }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('*.cabal') }}
+          restore-keys: |
+            stack-${{ runner.os }}-${{ matrix.resolver }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('stack.yaml') }}-
+            stack-${{ runner.os }}-${{ matrix.resolver }}-${{ steps.cache-date.outputs.date }}-
+            stack-${{ runner.os }}-${{ matrix.resolver }}-
+
+      - name: Update hackage index
+        # always update index to prevent the shared ~/.stack/pantry cache from being empty
+        run: stack update
+
+      - name: Pull in macOS dependencies
+        if: runner.os == 'macOS'
+        run: git submodule update --init
+
+      - name: Build and test
+        shell: bash
+        if: runner.os != 'macOS'
+        run: |
+          stack test \
+            --fast --no-terminal --skip-msys \
+            --resolver=${{ matrix.resolver }} --system-ghc
+
+      - name: Build and test (macOS)
+        shell: bash
+        if: runner.os == 'macOS'
+        run: |
+          stack test \
+            --fast --no-terminal \
+            --resolver=${{ matrix.resolver }} --system-ghc \
+            --flag kmonad:dext \
+            --extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit:c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        resolver: [lts-16, lts-18, nightly-2021-08-21]
+        resolver: [lts-16.31, lts-18.6, nightly-2021-08-21]
 
     steps:
       - name: Clone project

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -20,10 +20,18 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v2
 
+      - name: Get ghc version for ${{ matrix.resolver }}
+        shell: bash
+        run: |
+          GHCVER=$(curl -L https://www.stackage.org/${{ matrix.resolver }}/ghc-major-version)
+          echo "Got $GHCVER"
+          echo "::set-output name=ghc::$GHCVER"
+        id: ghc-version
+
       - uses: haskell/actions/setup@v1
         id: hs-setup
         with:
-          ghc-version: ${{ fromJSON('{"lts-16":"8.8.4","lts-18":"8.10.4","nightly-2021-08-21":"9.0.1"}')[matrix.resolver] }}
+          ghc-version: ${{ steps.ghc-version.outputs.ghc }}
           enable-stack: true
 
       - name: Refresh caches once a month

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        resolver: [lts-16.31, lts-18.6, nightly-2021-08-21]
+        resolver: [lts-14.27, lts-16.31, lts-18.6, nightly-2021-08-21]
 
     steps:
       - name: Clone project
@@ -29,6 +29,7 @@ jobs:
         id: ghc-version
 
       - uses: haskell/actions/setup@v1
+        name: Setup GHC ${{ steps.ghc-version.outputs.ghc }}
         id: hs-setup
         with:
           ghc-version: ${{ steps.ghc-version.outputs.ghc }}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,4 +15,7 @@ module Main
   )
 where
 
-import KMonad.App (main)
+import qualified KMonad.App as KMonad (main)
+
+main :: IO ()
+main = KMonad.main

--- a/src/KMonad/App/Main.hs
+++ b/src/KMonad/App/Main.hs
@@ -147,7 +147,9 @@ pressKey c =
         runRIO (KEnv app b) $ do
           runAction a
           awaitMy Release $ do
-            runBEnv b Release >>= maybe (pure ()) runAction
+            runBEnv b Release >>= \case
+              Nothing -> pure ()
+              Just a  -> runAction a
             pure Catch
 
 --------------------------------------------------------------------------------

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -199,9 +199,8 @@ getOverride = do
   foldM go env cfg
 
 -- | Turn a 'HasLogFunc'-only RIO into a function from LogFunc to IO
-runLF :: (forall e. HasLogFunc e => RIO e a) -> LogFunc -> IO a
+runLF :: HasLogFunc lf => RIO lf a -> lf -> IO a
 runLF = flip runRIO
-
 
 -- | Extract the KeySource-loader from the 'KExpr's
 getI :: J (LogFunc -> IO (Acquire KeySource))


### PR DESCRIPTION
This seems to work. Although I've just realized there aren't any automated tests, so "build and test" step is actually just "build".

macOS needs some additional arguments during build, I've opted to use a separate step instead of bash-fuing it. This leads to some duplication, but it's less obscure, I think.

Build fails on the latest nightly resolver due to changes in RIO API. I've allowed failures on nightly for that reason (whether GitHub UI picks up on this is anyone's guess -- it does on the [action page on my fork](https://github.com/lierdakil/kmonad/actions/runs/1154101823), but not here apparently)

I'm skipping local msys install on windows, which saves a minute or so in build time, and everything builds apparently, but ghc does complain about missing paths a fair bit.

One caveat is that changing/adding resolvers requires manually adding a corresponding GHC version to a JSON string on line 26. Could just let stack install the ghc version it wants, but it takes a while. Didn't think of a better way to handle this, suggestions are welcome. As to why not do it like in xmonad, that's because I don't want to define all (3 OSes)×(3 resolvers) variants (potentially more if you want to add more resolvers) manually, and we'd have to with `include`.
**EDIT:** actually, we can get GHC version from stackage. If stackage is down though, our CI is too.

**EDIT2:** Apparently stackage lts-18.7 just landed which uses GHC 8.10.6. Not yet available for Windows, so I've pinned minor lts versions, which seems like a good idea in general -- don't really want CI to suddenly start failing when nothing has changed on our side.