### PR TITLE
Update Stack to LTS 18.9

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.5
+resolver: lts-18.9
 packages:
 - .
 extra-deps:


### PR DESCRIPTION
GHC 8.10.7 contained in Stack LTS 18.9 allows compiling to native Apple Silicon code.
I've tested this both on an M1 and an Intel chip and both work nicely.
I don't know if there's any downsides to upgrading Stack?