### PR TITLE
optional :timeout-button for tap-hold-next{,-release}

### DIFF
--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -368,7 +368,8 @@ joinButton ns als =
     KAround o i        -> jst $ around             <$> go o <*> go i
     KTapNext t h       -> jst $ tapNext            <$> go t <*> go h
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h
-    KTapHoldNext s t h -> jst $ tapHoldNext (fi s) <$> go t <*> go h
+    KTapHoldNext s t h mtb
+      -> jst $ tapHoldNext (fi s) <$> go t <*> go h <*> traverse go mtb
     KTapNextRelease t h -> jst $ tapNextRelease    <$> go t <*> go h
     KTapHoldNextRelease ms t h mtb
       -> jst $ tapHoldNextRelease (fi ms) <$> go t <*> go h <*> traverse go mtb

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -370,8 +370,8 @@ joinButton ns als =
     KTapHold s t h     -> jst $ tapHold (fi s)     <$> go t <*> go h
     KTapHoldNext s t h -> jst $ tapHoldNext (fi s) <$> go t <*> go h
     KTapNextRelease t h -> jst $ tapNextRelease    <$> go t <*> go h
-    KTapHoldNextRelease ms t h
-      -> jst $ tapHoldNextRelease (fi ms) <$> go t <*> go h
+    KTapHoldNextRelease ms t h mtb
+      -> jst $ tapHoldNextRelease (fi ms) <$> go t <*> go h <*> traverse go mtb
     KAroundNext b      -> jst $ aroundNext         <$> go b
     KAroundNextSingle b -> jst $ aroundNextSingle <$> go b
     KAroundNextTimeout ms b t -> jst $ aroundNextTimeout (fi ms) <$> go b <*> go t

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -271,7 +271,8 @@ keywordButtons =
   , ("tap-next-release"
     , KTapNextRelease <$> buttonP <*> buttonP)
   , ("tap-hold-next-release"
-    , KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP)
+    , KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP
+                          <*> optional (keywordP "timeout-button" buttonP))
   , ("tap-next"       , KTapNext     <$> buttonP     <*> buttonP)
   , ("layer-toggle"   , KLayerToggle <$> lexeme word)
   , ("layer-switch"   , KLayerSwitch <$> lexeme word)

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -130,7 +130,7 @@ bool = symbol "true" *> pure True
 
 -- | Parse a LISP-like keyword of the form @:keyword value@
 keywordP :: Text -> Parser p -> Parser p
-keywordP kw p = lexeme (string (":" <> kw)) *> lexeme p
+keywordP kw p = symbol (":" <> kw) *> lexeme p
   <?> "Keyword " <> ":" <> T.unpack kw
 
 --------------------------------------------------------------------------------

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -267,7 +267,9 @@ keywordButtons =
   [ ("around"         , KAround      <$> buttonP     <*> buttonP)
   , ("multi-tap"      , KMultiTap    <$> timed       <*> buttonP)
   , ("tap-hold"       , KTapHold     <$> lexeme numP <*> buttonP <*> buttonP)
-  , ("tap-hold-next"  , KTapHoldNext <$> lexeme numP <*> buttonP <*> buttonP)
+  , ("tap-hold-next"
+    , KTapHoldNext <$> lexeme numP <*> buttonP <*> buttonP
+                   <*> optional (keywordP "timeout-button" buttonP))
   , ("tap-next-release"
     , KTapNextRelease <$> buttonP <*> buttonP)
   , ("tap-hold-next-release"

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -88,7 +88,7 @@ data DefButton
   | KTapHold Int DefButton DefButton       -- ^ Do 2 things based on behavior and delay
   | KTapHoldNext Int DefButton DefButton   -- ^ Mixture between KTapNext and KTapHold
   | KTapNextRelease DefButton DefButton    -- ^ Do 2 things based on behavior
-  | KTapHoldNextRelease Int DefButton DefButton
+  | KTapHoldNextRelease Int DefButton DefButton (Maybe DefButton)
     -- ^ Like KTapNextRelease but with a timeout
   | KAroundNext DefButton                  -- ^ Surround a future button
   | KAroundNextSingle DefButton            -- ^ Surround a future button

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -86,7 +86,8 @@ data DefButton
   | KLayerRem Text                         -- ^ Remove top instance of a layer when pressed
   | KTapNext DefButton DefButton           -- ^ Do 2 things based on behavior
   | KTapHold Int DefButton DefButton       -- ^ Do 2 things based on behavior and delay
-  | KTapHoldNext Int DefButton DefButton   -- ^ Mixture between KTapNext and KTapHold
+  | KTapHoldNext Int DefButton DefButton (Maybe DefButton)
+    -- ^ Mixture between KTapNext and KTapHold
   | KTapNextRelease DefButton DefButton    -- ^ Do 2 things based on behavior
   | KTapHoldNextRelease Int DefButton DefButton (Maybe DefButton)
     -- ^ Like KTapNextRelease but with a timeout

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -254,12 +254,15 @@ tapNext t h = onPress $ hookF InputHook $ \e -> do
     else press h *> pure NoCatch
 
 -- | Like 'tapNext', except that after some interval it switches anyways
-tapHoldNext :: Milliseconds -> Button -> Button -> Button
-tapHoldNext ms t h = onPress $ within ms (pure $ const True) (press h) $ \tr -> do
+tapHoldNext :: Milliseconds -> Button -> Button -> Maybe Button -> Button
+tapHoldNext ms t h mtb = onPress $ within ms (pure $ const True) onTimeout $ \tr -> do
   p <- matchMy Release
   if p $ tr^.event
     then tap t   *> pure Catch
     else press h *> pure NoCatch
+  where
+    onTimeout :: MonadK m =>  m ()
+    onTimeout = press $ fromMaybe h mtb
 
 -- | Create a tap-hold style button that makes its decision based on the next
 -- detected release in the following manner:

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -300,19 +300,20 @@ tapNextRelease t h = onPress $ do
     doHold e = press h *> hold False *> inject e *> pure Catch
 
 
+
 -- | Create a tap-hold style button that makes its decision based on the next
 -- detected release in the following manner:
 -- 1. It is the release of this button: We are tapping
 -- 2. It is of some other button that was pressed *before* this one, ignore.
 -- 3. It is of some other button that was pressed *after* this one, we hold.
 --
--- If we encounter the timeout before any other release, we switch to holding
--- mode.
+-- If we encounter the timeout before any other release, we switch to the
+-- specified timeout button, or to the hold button if none is specified.
 --
 -- It does all of this while holding processing of other buttons, so time will
 -- get rolled back like a TapHold button.
-tapHoldNextRelease :: Milliseconds -> Button -> Button -> Button
-tapHoldNextRelease ms t h = onPress $ do
+tapHoldNextRelease :: Milliseconds -> Button -> Button -> Maybe Button -> Button
+tapHoldNextRelease ms t h mtb = onPress $ do
   hold True
   go ms []
   where
@@ -333,7 +334,7 @@ tapHoldNextRelease ms t h = onPress $ do
         | otherwise -> go (ms' - r^.elapsed) ks *> pure NoCatch
 
     onTimeout :: MonadK m =>  m ()
-    onTimeout = press h *> hold False
+    onTimeout = press (fromMaybe h mtb) *> hold False
 
     onRelSelf :: MonadK m => m Catch
     onRelSelf = tap t *> hold False *> pure Catch


### PR DESCRIPTION
If the `:timeout-button` argument is specified, `tap-hold-next-release` will switch to that button instead of the hold button if the timeout elapses. This makes it possible to make implement a button which can both be tapped and pressed-and-held in order to type 1 or multiple (via the operating system's auto-repeat functionality) copies of a character, while still behaving as a modifier key when pressed in combination with other keys.

Fixes #378.