### PR TITLE
Restrict text parser to double quotes

### DIFF
--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -146,11 +146,11 @@ keycodeP = fromNamed (Q.reverse keyNames ^.. Q.itemed) <?> "keycode"
 numP :: Parser Int
 numP = L.decimal
 
--- | Parse text with escaped characters between "s
+-- | Parse text with escaped characters between double quotes.
 textP :: Parser Text
 textP = do
-  _ <- char '\"' <|> char '\''
-  s <- manyTill L.charLiteral (char '\"' <|> char '\'')
+  _ <- char '\"'
+  s <- manyTill L.charLiteral (char '\"')
   pure . T.pack $ s
 
 -- | Parse a variable reference


### PR DESCRIPTION
Single quotes were originally introduced for CLI options, where
delimiting string by them is not that uncommon. For lisps this is quite
unusual and may even give syntax highlighters some trouble if they do
not know about `.kbd` files—and most editors don't, at this point.

As an additional bonus, this fixes a bug because the old implementation
did not correctly associate beginning delimiters with matching ending
ones.

Fixes: https://github.com/kmonad/kmonad/issues/385