### PR TITLE
Add Ú compose sequence

### DIFF
--- a/src/KMonad/Keyboard/ComposeSeq.hs
+++ b/src/KMonad/Keyboard/ComposeSeq.hs
@@ -148,6 +148,7 @@ ssComposed =
     , ("~ O"      , 'Õ'     , "Otilde")
     , ("\" O"     , 'Ö'     , "Odiaeresis")
     , ("\" U"     , 'Ü'     , "Udiaeresis")
+    , ("' U"      , 'Ú'     , "Uacute")
     , ("x x"      , '×'     , "multiply")
     , ("/ O"      , 'Ø'     , "Oslash")
     , ("' Y"      , 'Ý'     , "Yacute")


### PR DESCRIPTION
These already come with X11, or at least I can see them in my `/usr/share/X11/locale/en_US.UTF-8/Compose`.

In Spanish they are extremely rare but still valid.