### PR TITLE
typo: /etv/ -> /etc/

### DIFF
--- a/startup/run
+++ b/startup/run
@@ -6,7 +6,7 @@
 #
 # How to use this service:
 #
-# 1. Place this file in the `/etv/sv/kmonad' directory.  You will need
+# 1. Place this file in the `/etc/sv/kmonad' directory.  You will need
 #    to create this directory; this is most easily done with `xmksv'
 #    from the `xtools' package:
 #


### PR DESCRIPTION
...for the very small number of people who might be reading this doc but not able recognize & correct this error.