### PR TITLE
Add a note regarding dext activation failure

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -229,6 +229,9 @@ install the extension, and activate the extension.
   $ /Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Manager activate
 ```
 
+Note: If activation failed (e.g. because a newer version is already installed), replace `activate` in the above command with `forceActivate` and try again.
+
+
 #### Installing kmonad
 
 Compilation under Mac currently works with `stack`. Compilation under


### PR DESCRIPTION
Suggest `forceActivate` if using `activate` failed.

P.S. This should also be added in `keycode-refactor`. When merging, could you also update it? If not, I can open a new PR.