### PR TITLE
[Mac] Support more identifiers for filtering devices

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/pqrs-org/Karabiner-VirtualHIDDevice.git
 [submodule "Karabiner-DriverKit-VirtualHIDDevice"]
 	path = c_src/mac/Karabiner-DriverKit-VirtualHIDDevice
-	url = https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice.git
+	url = https://github.com/MuhammedZakir/Karabiner-DriverKit-VirtualHIDDevice.git

--- a/c_src/mac/Makefile
+++ b/c_src/mac/Makefile
@@ -1,2 +1,6 @@
-all: list-keyboards.c
-	gcc $< -o list-keyboards -framework IOKit -framework CoreFoundation
+clang = /usr/bin/clang
+framework = -framework IOKit -framework CoreFoundation
+
+all: list-keyboards.c device_properties.c
+	$(clang) $^ -o list-keyboards $(framework)
+

--- a/c_src/mac/common.hpp
+++ b/c_src/mac/common.hpp
@@ -1,0 +1,17 @@
+#include <unistd.h>
+
+/*
+ * Key event information that's shared between C++ and Haskell.
+ *
+ * type: represents key up or key down
+ * page: represents IOKit usage page
+ * usage: represents IOKit usage
+ */
+struct KeyEvent {
+    uint64_t type;
+    uint32_t page;
+    uint32_t usage;
+};
+
+// defined in keyio_mac.cpp
+void print_iokit_error(const char *fname, int freturn = 0);

--- a/c_src/mac/device_properties.c
+++ b/c_src/mac/device_properties.c
@@ -13,7 +13,7 @@ bool get_number(CFTypeRef value, int64_t *varPtr)
 /* Get a string value out of a CFType object. */
 char *get_cstring(CFTypeRef value)
 {
-    return CFStringGetCStringPtr((CFStringRef) value, kCFStringEncodingUTF8);
+    return (char *)CFStringGetCStringPtr((CFStringRef) value, kCFStringEncodingUTF8);
 }
 
 /* Get a property of the device. */

--- a/c_src/mac/device_properties.c
+++ b/c_src/mac/device_properties.c
@@ -29,7 +29,7 @@ CFTypeRef get_property_by_ioreg(mach_port_t device, CFStringRef property)
 #define GET_NUMBER_PROPERTY(key, var) get_number(get_property_by_ioreg(_device, CFSTR(key)), var)
 #define GET_STRING_PROPERTY(key) get_cstring(get_property_by_ioreg(_device, CFSTR(key)))
 
-    void
+void
 get_device_properties(mach_port_t _device, struct device_properties *properties)
 {
     properties->product_name = GET_STRING_PROPERTY(kIOHIDProductKey);
@@ -51,7 +51,8 @@ void print_device_properties(struct device_properties *properties)
 {
     if (properties == NULL)
         return;
-
+    
+    printf("=========================\n");
     PRINT_STRING_PROPERTY(product_name);
     PRINT_STRING_PROPERTY(manufacturer);
     PRINT_STRING_PROPERTY(serial_number);
@@ -62,59 +63,38 @@ void print_device_properties(struct device_properties *properties)
     PRINT_NUMBER_PROPERTY(location_id);
     PRINT_NUMBER_PROPERTY(country_code);
     PRINT_NUMBER_PROPERTY(version_number);
+    printf("=========================\n");
 
     // printf("is_built_in: %s\n", properties.is_built_in ? "true" : "false");
 }
 
-/* str1 has higher priority */
+/* `str1` has higher priority - NULL or "" means empty. */
 bool compare_string_props(const char *str1, const char *str2)
 {
-    /* Whether 2 strings were *actually* compared at least once.
-     *
-     * E.g. without this, below comparison would be `true`,
-     * although it should be `false`.
-     *  identifiers.prop1 = device_props.prop1 = "same";
-     *  identifiers.prop2 = ""; device_props.prop2 = "diff";
-     *  match = identifiers.prop1 == device_props.prop1;
-     *  match = match && (identifiers.prop2 == device_props.prop2);
-     */
-    static bool comparedOnce = false;
-
-    if (!comparedOnce)
-    {
-        // If str1 is empty, don't compare as empty string is
-        // taken as default value. Unless properties are
-        // *actually* compared atleast once.
-        if (str1 == NULL || str1[0] == '\0')
-            return true;
-    }
-
-    if (str1 == NULL && str2 == NULL)
+    if (str1 == NULL || str1[0] == '\0')
         return true;
-    else if (str1 == NULL || str2 == NULL)
+
+    if (str2 == NULL)
         return false;
 
-    comparedOnce = true;
     return strcmp(str1, str2) == 0;
 }
 
-/* rules are same as above - 0 is considered as empty. */
+/* `num1` has higher priority - 0 means empty. */
 bool compare_number_props(const int64_t num1, const int64_t num2)
 {
-    static bool comparedOnce = false;
-
-    if (!comparedOnce && num1 == 0)
+    if (num1 == 0)
         return true;
 
-    comparedOnce = true;
     return num1 == num2;
 }
 
 #define COMPARE_STRING_PROPS(PROP) (compare_string_props(props1->PROP, props2->PROP))
 #define COMPARE_NUMBER_PROPS(PROP) (compare_number_props(props1->PROP, props2->PROP))
 
-bool compare_device_properties(struct device_properties *props1,
-        struct device_properties *props2)
+bool
+compare_device_properties(struct device_properties *props1,
+                          struct device_properties *props2)
 {
     if (props1 == NULL)
         return true;
@@ -123,20 +103,15 @@ bool compare_device_properties(struct device_properties *props1,
         return false;
 
     bool match = COMPARE_STRING_PROPS(product_name)  ;
-    printf("product match: %s\n", match ? "true" : "false");
     match = match && COMPARE_STRING_PROPS(manufacturer)  ;
-    printf("manufacturer match: %s\n", match ? "true" : "false");
     match = match && COMPARE_STRING_PROPS(serial_number) ;
-    printf("serial_number match: %s\n", match ? "true" : "false");
     match = match && COMPARE_STRING_PROPS(transport);
-    printf("transport match: %s\n", match ? "true" : "false");
     match = match && \
             COMPARE_NUMBER_PROPS(product_id)     && \
             COMPARE_NUMBER_PROPS(vendor_id)      && \
             COMPARE_NUMBER_PROPS(location_id)    && \
             COMPARE_NUMBER_PROPS(country_code)   && \
             COMPARE_NUMBER_PROPS(version_number);
-    printf("final match: %s\n", match ? "true" : "false");
 
     return match;
 }

--- a/c_src/mac/device_properties.c
+++ b/c_src/mac/device_properties.c
@@ -1,0 +1,142 @@
+#include <IOKit/IOKitLib.h> // IORegistryEntryCreateCFProperty
+#include <stdlib.h>
+#include <string.h>
+
+#include "device_properties.h"
+
+/* Get a number value out of a CFType object. */
+bool get_number(CFTypeRef value, int64_t *varPtr)
+{
+    return CFNumberGetValue((CFNumberRef) value, kCFNumberSInt64Type, varPtr);
+}
+
+/* Get a string value out of a CFType object. */
+char *get_cstring(CFTypeRef value)
+{
+    return CFStringGetCStringPtr((CFStringRef) value, kCFStringEncodingUTF8);
+}
+
+/* Get a property of the device. */
+CFTypeRef get_property_by_ioreg(mach_port_t device, CFStringRef property)
+{
+    return IORegistryEntryCreateCFProperty(
+            device,
+            property,
+            kCFAllocatorDefault,
+            kIOHIDOptionsTypeNone);
+}
+
+#define GET_NUMBER_PROPERTY(key, var) get_number(get_property_by_ioreg(_device, CFSTR(key)), var)
+#define GET_STRING_PROPERTY(key) get_cstring(get_property_by_ioreg(_device, CFSTR(key)))
+
+    void
+get_device_properties(mach_port_t _device, struct device_properties *properties)
+{
+    properties->product_name = GET_STRING_PROPERTY(kIOHIDProductKey);
+    properties->transport = GET_STRING_PROPERTY(kIOHIDTransportKey);
+    properties->serial_number = GET_STRING_PROPERTY(kIOHIDSerialNumberKey);
+    properties->manufacturer = GET_STRING_PROPERTY(kIOHIDManufacturerKey);
+
+    GET_NUMBER_PROPERTY(kIOHIDCountryCodeKey, &properties->country_code);
+    GET_NUMBER_PROPERTY(kIOHIDLocationIDKey, &properties->location_id);
+    GET_NUMBER_PROPERTY(kIOHIDProductIDKey, &properties->product_id);
+    GET_NUMBER_PROPERTY(kIOHIDVendorIDKey, &properties->vendor_id);
+    GET_NUMBER_PROPERTY(kIOHIDVersionNumberKey, &properties->version_number);
+}
+
+#define PRINT_STRING_PROPERTY(PROP) if(properties->PROP != NULL) printf(#PROP": %s\n", properties->PROP)
+#define PRINT_NUMBER_PROPERTY(PROP) if(properties->PROP != 0) printf(#PROP": %lld\n", properties->PROP)
+
+void print_device_properties(struct device_properties *properties)
+{
+    if (properties == NULL)
+        return;
+
+    PRINT_STRING_PROPERTY(product_name);
+    PRINT_STRING_PROPERTY(manufacturer);
+    PRINT_STRING_PROPERTY(serial_number);
+    PRINT_STRING_PROPERTY(transport);
+    printf("----------\n");
+    PRINT_NUMBER_PROPERTY(product_id);
+    PRINT_NUMBER_PROPERTY(vendor_id);
+    PRINT_NUMBER_PROPERTY(location_id);
+    PRINT_NUMBER_PROPERTY(country_code);
+    PRINT_NUMBER_PROPERTY(version_number);
+
+    // printf("is_built_in: %s\n", properties.is_built_in ? "true" : "false");
+}
+
+/* str1 has higher priority */
+bool compare_string_props(const char *str1, const char *str2)
+{
+    /* Whether 2 strings were *actually* compared at least once.
+     *
+     * E.g. without this, below comparison would be `true`,
+     * although it should be `false`.
+     *  identifiers.prop1 = device_props.prop1 = "same";
+     *  identifiers.prop2 = ""; device_props.prop2 = "diff";
+     *  match = identifiers.prop1 == device_props.prop1;
+     *  match = match && (identifiers.prop2 == device_props.prop2);
+     */
+    static bool comparedOnce = false;
+
+    if (!comparedOnce)
+    {
+        // If str1 is empty, don't compare as empty string is
+        // taken as default value. Unless properties are
+        // *actually* compared atleast once.
+        if (str1 == NULL || str1[0] == '\0')
+            return true;
+    }
+
+    if (str1 == NULL && str2 == NULL)
+        return true;
+    else if (str1 == NULL || str2 == NULL)
+        return false;
+
+    comparedOnce = true;
+    return strcmp(str1, str2) == 0;
+}
+
+/* rules are same as above - 0 is considered as empty. */
+bool compare_number_props(const int64_t num1, const int64_t num2)
+{
+    static bool comparedOnce = false;
+
+    if (!comparedOnce && num1 == 0)
+        return true;
+
+    comparedOnce = true;
+    return num1 == num2;
+}
+
+#define COMPARE_STRING_PROPS(PROP) (compare_string_props(props1->PROP, props2->PROP))
+#define COMPARE_NUMBER_PROPS(PROP) (compare_number_props(props1->PROP, props2->PROP))
+
+bool compare_device_properties(struct device_properties *props1,
+        struct device_properties *props2)
+{
+    if (props1 == NULL)
+        return true;
+
+    if (props2 == NULL)
+        return false;
+
+    bool match = COMPARE_STRING_PROPS(product_name)  ;
+    printf("product match: %s\n", match ? "true" : "false");
+    match = match && COMPARE_STRING_PROPS(manufacturer)  ;
+    printf("manufacturer match: %s\n", match ? "true" : "false");
+    match = match && COMPARE_STRING_PROPS(serial_number) ;
+    printf("serial_number match: %s\n", match ? "true" : "false");
+    match = match && COMPARE_STRING_PROPS(transport);
+    printf("transport match: %s\n", match ? "true" : "false");
+    match = match && \
+            COMPARE_NUMBER_PROPS(product_id)     && \
+            COMPARE_NUMBER_PROPS(vendor_id)      && \
+            COMPARE_NUMBER_PROPS(location_id)    && \
+            COMPARE_NUMBER_PROPS(country_code)   && \
+            COMPARE_NUMBER_PROPS(version_number);
+    printf("final match: %s\n", match ? "true" : "false");
+
+    return match;
+}

--- a/c_src/mac/device_properties.h
+++ b/c_src/mac/device_properties.h
@@ -3,8 +3,8 @@
 #include <stdint.h>
 
 struct device_properties {
-    char *product_name;
     char *manufacturer;
+    char *product_name;
     char *serial_number;
     char *transport;
 

--- a/c_src/mac/device_properties.h
+++ b/c_src/mac/device_properties.h
@@ -1,0 +1,23 @@
+#include <stdbool.h>
+#include <IOKit/hid/IOHIDLib.h>
+#include <stdint.h>
+
+struct device_properties {
+    char *product_name;
+    char *manufacturer;
+    char *serial_number;
+    char *transport;
+
+    int64_t country_code;
+    int64_t location_id;
+    int64_t product_id;
+    int64_t vendor_id;
+    int64_t version_number;
+
+    // bool is_built_in;
+};
+
+void get_device_properties(mach_port_t _device, struct device_properties *properties);
+void print_device_properties(struct device_properties *properties);
+bool compare_device_properties(struct device_properties *props1,
+                               struct device_properties *prop2);

--- a/c_src/mac/dext.cpp
+++ b/c_src/mac/dext.cpp
@@ -1,7 +1,6 @@
-#include "keyio_mac.hpp"
-
 #include "virtual_hid_device_driver.hpp"
 #include "virtual_hid_device_service.hpp"
+#include "common.hpp"
 
 /*
  * Resources needed to post altered key events back to the OS. They
@@ -19,39 +18,41 @@ int init_sink() {
     std::filesystem::path client_socket_file_path("/tmp/karabiner_driverkit_virtual_hid_device_service_client.sock");
     client = new pqrs::karabiner::driverkit::virtual_hid_device_service::client(client_socket_file_path);
     auto copy = client;
+
     client->async_driver_loaded();
     client->async_driver_version_matched();
     client->async_virtual_hid_keyboard_ready();
     client->async_virtual_hid_pointing_ready();
+
     /**/
     client->connected.connect([copy] {
-                                  std::cout << "connected" << std::endl;
-                                  copy->async_virtual_hid_keyboard_initialize(pqrs::hid::country_code::us);
-                              });
+        std::cout << "connected" << std::endl;
+        copy->async_virtual_hid_keyboard_initialize(pqrs::hid::country_code::us);
+    });
     client->connect_failed.connect([](auto&& error_code) {
-                                       std::cout << "connect_failed " << error_code << std::endl;
-                                   });
+        std::cout << "connect_failed " << error_code << std::endl;
+    });
     client->closed.connect([] {
-                               std::cout << "closed" << std::endl;
-                           });
+        std::cout << "closed" << std::endl;
+    });
     client->error_occurred.connect([](auto&& error_code) {
-                                       std::cout << "error_occurred " << error_code << std::endl;
-                                   });
+        std::cout << "error_occurred " << error_code << std::endl;
+    });
     client->driver_loaded_response.connect([](auto&& driver_loaded) {
-                                               static std::optional<bool> previous_value;
+        static std::optional<bool> previous_value;
 
-                                               if (previous_value != driver_loaded) {
-                                                   std::cout << "driver_loaded " << driver_loaded << std::endl;
-                                                   previous_value = driver_loaded;
-                                               }
-                                           });
+        if (previous_value != driver_loaded) {
+          std::cout << "driver_loaded " << driver_loaded << std::endl;
+          previous_value = driver_loaded;
+        }
+    });
     client->driver_version_matched_response.connect([](auto&& driver_version_matched) {
-                                                        static std::optional<bool> previous_value;
-                                                        if (previous_value != driver_version_matched) {
-                                                            std::cout << "driver_version_matched " << driver_version_matched << std::endl;
-                                                            previous_value = driver_version_matched;
-                                                        }
-                                                    });
+        static std::optional<bool> previous_value;
+        if (previous_value != driver_version_matched) {
+          std::cout << "driver_version_matched " << driver_version_matched << std::endl;
+          previous_value = driver_version_matched;
+        }
+    });
     /**/
     client->async_start();
     return 0;

--- a/c_src/mac/kext.cpp
+++ b/c_src/mac/kext.cpp
@@ -1,6 +1,5 @@
-#include "keyio_mac.hpp"
-
 #include "karabiner_virtual_hid_device_methods.hpp"
+#include "common.hpp"
 
 /*
  * Resources needed to post altered key events back to the OS. They

--- a/c_src/mac/keyio_mac.cpp
+++ b/c_src/mac/keyio_mac.cpp
@@ -154,6 +154,15 @@ extern "C" int wait_key(struct KeyEvent *e) {
 }
 
 /*
+ * `kIOMasterPortDefault` is deprecated in macOS 12.
+ */
+#ifdef __MAC_12_0
+  #define _kIOMainPortDefault kIOMainPortDefault
+#else
+  #define _kIOMainPortDefault kIOMasterPortDefault
+#endif
+
+/*
  * For each keyboard, registers an asynchronous callback to run when
  * new input from the user is available from that keyboard. Then
  * sleeps indefinitely, ready to received asynchronous callbacks.
@@ -177,7 +186,7 @@ static void monitor_kb(struct device_properties *identifiers) {
     CFRelease(cfValue);
     io_iterator_t iter = IO_OBJECT_NULL;
     CFRetain(matching_dictionary);
-    kr = IOServiceGetMatchingServices(kIOMasterPortDefault,
+    kr = IOServiceGetMatchingServices(_kIOMainPortDefault,
                                       matching_dictionary,
                                       &iter);
     if(kr != KERN_SUCCESS) {
@@ -186,7 +195,7 @@ static void monitor_kb(struct device_properties *identifiers) {
     }
     listener_loop = CFRunLoopGetCurrent();
     open_matching_devices(identifiers, iter);
-    IONotificationPortRef notification_port = IONotificationPortCreate(kIOMasterPortDefault);
+    IONotificationPortRef notification_port = IONotificationPortCreate(_kIOMainPortDefault);
     CFRunLoopSourceRef notification_source = IONotificationPortGetRunLoopSource(notification_port);
     CFRunLoopAddSource(listener_loop, notification_source, kCFRunLoopDefaultMode);
     CFRetain(matching_dictionary);

--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -4,6 +4,15 @@
 
 #include "device_properties.h"
 
+/*
+ * `kIOMasterPortDefault` is deprecated in macOS 12.
+ */
+#ifdef __MAC_12_0
+  #define _kIOMainPortDefault kIOMainPortDefault
+#else
+  #define _kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 int main() {
     CFMutableDictionaryRef matching_dictionary = IOServiceMatching(kIOHIDDeviceKey);
     if(!matching_dictionary) {
@@ -25,7 +34,7 @@ int main() {
     CFRelease(cfValue);
 
     io_iterator_t iter = IO_OBJECT_NULL;
-    kern_return_t r = IOServiceGetMatchingServices(kIOMasterPortDefault,
+    kern_return_t r = IOServiceGetMatchingServices(_kIOMainPortDefault,
                                                    matching_dictionary,
                                                    &iter);
     if(r != KERN_SUCCESS) {

--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -43,9 +43,7 @@ int main() {
     printf("Note: only prints non-empty fields.\n\n");
     for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
         get_device_properties(curr, properties);
-        printf("=========================\n");
         print_device_properties(properties);
-        printf("=========================\n");
     }
 
     free(properties);

--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -1,5 +1,8 @@
 #include <IOKit/hid/IOHIDLib.h>
 #include <IOKit/hidsystem/IOHIDShared.h>
+#include <stdlib.h> // free
+
+#include "device_properties.h"
 
 int main() {
     CFMutableDictionaryRef matching_dictionary = IOServiceMatching(kIOHIDDeviceKey);
@@ -7,16 +10,20 @@ int main() {
         fprintf(stderr,"IOServiceMatching failed");
         return 1;
     }
+
     UInt32 value;
     CFNumberRef cfValue;
+
     value = kHIDPage_GenericDesktop;
     cfValue = CFNumberCreate( kCFAllocatorDefault, kCFNumberSInt32Type, &value );
     CFDictionarySetValue(matching_dictionary, CFSTR(kIOHIDDeviceUsagePageKey), cfValue);
     CFRelease(cfValue);
+
     value = kHIDUsage_GD_Keyboard;
     cfValue = CFNumberCreate( kCFAllocatorDefault, kCFNumberSInt32Type, &value );
     CFDictionarySetValue(matching_dictionary,CFSTR(kIOHIDDeviceUsageKey),cfValue);
     CFRelease(cfValue);
+
     io_iterator_t iter = IO_OBJECT_NULL;
     kern_return_t r = IOServiceGetMatchingServices(kIOMasterPortDefault,
                                                    matching_dictionary,
@@ -25,12 +32,22 @@ int main() {
         fprintf(stderr,"IOServiceGetMatchingServices failed");
         return r;
     }
-    for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
-        CFTypeRef str = IORegistryEntryCreateCFProperty(curr,
-                                                        CFSTR("Product"),
-                                                        kCFAllocatorDefault,
-                                                        kIOHIDOptionsTypeNone);
-        CFShow(str);
+
+    struct device_properties *properties = malloc(sizeof *properties);
+    if (properties == NULL)
+    {
+        fprintf(stderr, "malloc error: device properties");
+        return 1;
     }
+
+    printf("Note: only prints non-empty fields.\n\n");
+    for(mach_port_t curr = IOIteratorNext(iter); curr; curr = IOIteratorNext(iter)) {
+        get_device_properties(curr, properties);
+        printf("=========================\n");
+        print_device_properties(properties);
+        printf("=========================\n");
+    }
+
+    free(properties);
     return 0;
 }

--- a/c_src/mac/tests/Makefile
+++ b/c_src/mac/tests/Makefile
@@ -1,0 +1,11 @@
+clang = /usr/bin/clang
+framework = -framework IOKit -framework CoreFoundation
+
+.PHONY: test
+test: ../device_properties.c
+	$(clang) $^ *.c -o test.bin $(framework)
+	./test.bin
+
+.PHONY: clean
+clean: test.bin
+	rm test.bin

--- a/c_src/mac/tests/compare_device_properties.c
+++ b/c_src/mac/tests/compare_device_properties.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../device_properties.h"
+
+struct device_properties *dp1 = NULL;
+struct device_properties *dp2 = NULL;
+
+int success_count = 0;
+int failure_count = 0;
+int tests_count = 0;
+
+void compare(char *msg, bool expected_result)
+{
+  tests_count++;
+  printf("=============================\n");
+  printf("%s\n", msg);
+  bool match = compare_device_properties(dp1, dp2);
+  match == expected_result ? success_count++ : failure_count++;
+  printf("MATCH: %s\n", match ? "TRUE" : "FALSE");
+  printf("=============================\n");
+  printf("dp1's properties:\n");
+  print_device_properties(dp1);
+  printf("\n");
+  printf("dp2's properties:\n");
+  print_device_properties(dp2);
+  printf("-----------------------------\n");
+  printf("-----------------------------\n\n");
+}
+
+int main()
+{
+  printf("Comparing 2 `device_properties`.\n\n");
+  printf("Note: first one has higher priority.\n");
+  printf("e.g. compare(user provided identifiers, keyboard's properties)\n\n");
+
+  compare("1. Compare: when both are NULL", true);
+
+  dp1 = calloc(1, sizeof *dp1);
+  dp1->product_name = "A Keyboard";
+  compare("2. Compare: when 2nd is NULL", false);
+
+  dp2 = calloc(1, sizeof *dp2);
+  dp2->manufacturer = "Manufacturer";
+  compare("3. Compare: different string properties", false);
+
+  dp2->product_name = "A Keyboard";
+  compare("4. Compare: same string property | dp2 - another string property", false);
+
+  dp1->location_id = 1234;
+  compare("5. Compare: same string property | dp2 - another string property | dp1 - number property", false);
+
+  dp2->vendor_id = 1234;
+  compare("6. Compare: same string property | dp2 - another string property | different number property", false);
+
+  dp1->vendor_id = 1234;
+  dp2->location_id = 1234;
+  compare("7. Compare: same properties - string(1), number(2) | dp2 - another string property", false);
+
+  dp1->manufacturer = "Manufacturer";
+  compare("8. Compare: same properties - string(2) , number(2)", true);
+
+  dp1->serial_number = "Serial Number";
+  dp2->serial_number = "Serial Number";
+  dp1->transport = "USB";
+  dp2->transport = "USB";
+  dp1->product_id = 14;
+  dp2->product_id = 14;
+  dp1->vendor_id = 73;
+  dp2->vendor_id = 73;
+  dp1->country_code = 66;
+  dp2->country_code = 66;
+  dp1->version_number = 89;
+  dp2->version_number = 89;
+  compare("9. Compare: all properties are SAME", true);
+
+  printf("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%");
+  printf("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n");
+  printf("TOTAL: %d  | SUCCESS: %d  | FAILURE: %d\n",
+          tests_count, success_count, failure_count);
+  printf("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%");
+  printf("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n");
+  return 0;
+}

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -178,6 +178,8 @@ library
       KMonad.App.KeyIO.Mac.IOKitSource
       KMonad.App.KeyIO.Mac.Ext
       KMonad.Util.Keyboard.Mac
+    cxx-sources:
+      c_src/mac/keyio_mac.cpp
     if flag(kext)
       include-dirs:
         c_src/mac/Karabiner-VirtualHIDDevice/dist/include
@@ -189,6 +191,8 @@ library
       include-dirs:
         c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit
         c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
+      c-sources:
+        c_src/mac/device_properties.c
       cxx-sources:
         c_src/mac/dext.cpp
       cxx-options:

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -192,7 +192,7 @@ library
       cxx-sources:
         c_src/mac/dext.cpp
       cxx-options:
-        -std=c++2a
+        -std=gnu++2a
     extra-libraries:
       c++
     build-depends:

--- a/src/KMonad/App/KeyIO/Common/Types.hs
+++ b/src/KMonad/App/KeyIO/Common/Types.hs
@@ -71,14 +71,23 @@ instance Default UinputCfg where
 -- $cfgs-mac
 
 -- | Holds the product string of keyboard if given. Else, Nothing.
-newtype IOKitCfg = IOKitCfg
-  { _productStr :: Maybe Text
+data IOKitCfg = IOKitCfg
+  -- Prepend `cfg` to distinguish from `DeviceProperties`'s fields.
+  { _cfgManufacturer :: Text
+  , _cfgProductName  :: Text
+  , _cfgSerialNumber :: Text
+  , _cfgTransport    :: Text
+  , _cfgCountryCode   :: Word64
+  , _cfgLocationID    :: Word64
+  , _cfgProductID     :: Word64
+  , _cfgVendorID      :: Word64
+  , _cfgVersionNumber :: Word64
   } deriving Show
 makeClassy ''IOKitCfg
 
 -- | By default, no product string (will grab all keyboards).
 instance Default IOKitCfg where
-  def = IOKitCfg Nothing
+  def = IOKitCfg "" "" "" "" 0 0 0 0 0
 
 -- | No config options for Kext/Dext
 data ExtCfg = ExtCfg deriving Show
@@ -107,7 +116,7 @@ instance HasKeyRepeatCfg SendEventCfg where keyRepeatCfg = seRepCfg
 
 data KeyInputCfg
   = LinuxEvdevCfg          EvdevCfg
-  | MacIOKitCfg            IOKitCfg
+  | MacIOKitCfg            (Maybe IOKitCfg)
   | WindowsLowLevelHookCfg LowLevelHookCfg
   deriving Show
 

--- a/src/KMonad/App/KeyIO/Mac/IOKitSource.hs
+++ b/src/KMonad/App/KeyIO/Mac/IOKitSource.hs
@@ -23,11 +23,54 @@ import KMonad.Util.Keyboard.Mac
 -------------------------------------------------------------------------------
 -- $ffi
 
+-- | DeviceProperties datatype
+--
+-- It is only used to filter devices when grabbing them.
+data DeviceProperties = DeviceProperties
+  { _manufacturer :: CString
+  , _productName  :: CString
+  , _serialNumber :: CString
+  , _transport    :: CString
+  , _countryCode   :: Word64
+  , _locationID    :: Word64
+  , _productID     :: Word64
+  , _vendorID      :: Word64
+  , _versionNumber :: Word64
+  } deriving Show
+-- makeClassy ''DeviceProperties
+
+-- | For sending struct from Haskell to C.
+instance Storable DeviceProperties where
+  alignment _ = 8
+  sizeOf    _ = 72
+  poke ptr (DeviceProperties mf pn sn tt cc lid pid vid vn) = do
+    pokeByteOff ptr  0 mf
+    pokeByteOff ptr  8 pn
+    pokeByteOff ptr 16 sn
+    pokeByteOff ptr 24 tt
+    pokeByteOff ptr 32 cc
+    pokeByteOff ptr 40 lid
+    pokeByteOff ptr 48 pid
+    pokeByteOff ptr 56 vid
+    pokeByteOff ptr 64 vn
+
+  peek ptr = do
+    mf  <- peekByteOff ptr  0
+    pn  <- peekByteOff ptr  8
+    sn  <- peekByteOff ptr 16
+    tt  <- peekByteOff ptr 24
+    cc  <- peekByteOff ptr 32
+    lid <- peekByteOff ptr 40
+    pid <- peekByteOff ptr 48
+    vid <- peekByteOff ptr 56
+    vn  <- peekByteOff ptr 64
+    return $ DeviceProperties mf pn sn tt cc lid pid vid vn
+
 -- | Use the mac c-api to grab keyboard(s)
 foreign import ccall "grab_kb"
-  grab_kb :: CString -> OnlyIO Word8
+  grab_kb :: Ptr DeviceProperties -> OnlyIO Word8
 
-grabKb :: CString -> OnlyIO ()
+grabKb :: Ptr DeviceProperties -> OnlyIO ()
 grabKb = void . grab_kb
 
 -- | Release the keyboard hook
@@ -53,30 +96,46 @@ waitKey ptr = do
 
 -------------------------------------------------------------------------------
 
-withIOKitSource :: LUIO m e => IOKitCfg -> Ctx r m GetKey
-withIOKitSource cfg = mkCtx $ \f -> do
+withIOKitSource :: LUIO m e => (Maybe IOKitCfg) -> Ctx r m GetKey
+withIOKitSource maybeCfg = mkCtx $ \f -> do
 
-  let prodStr :: Maybe Text
-      prodStr = cfg^.productStr
+  let deviceProperties :: IOKitCfg -> OnlyIO (Ptr DeviceProperties)
+      deviceProperties cfg = do
+        ptr <- calloc
+
+        let makeStr cfg id = newCString $ unpack (cfg^.id)
+
+        mf <- makeStr cfg cfgManufacturer
+        pn <- makeStr cfg cfgProductName
+        sn <- makeStr cfg cfgSerialNumber
+        tt <- makeStr cfg cfgTransport
+        poke ptr $ DeviceProperties
+                   { _manufacturer = mf
+                   , _productName  = pn
+                   , _serialNumber = sn
+                   , _transport    = tt
+                   , _countryCode   = cfg^.cfgCountryCode
+                   , _locationID    = cfg^.cfgLocationID
+                   , _productID     = cfg^.cfgProductID
+                   , _vendorID      = cfg^.cfgVendorID
+                   , _versionNumber = cfg^.cfgVersionNumber
+                   }
+        return ptr
 
   let init :: LUIO m e => m (Ptr RawEvent)
       init = do
-        case prodStr of
+        case (maybeCfg) of
           Nothing -> do
-            logInfo "Opening HID devices"
             liftIO $ grabKb nullPtr
-          Just s -> do
-            logInfo $ "Opening HID device: " <> s
-            liftIO $ withCString (unpack s) grabKb
+          (Just cfg) -> do
+            liftIO $ deviceProperties cfg >>= grabKb
 
+        logInfo "Opening HID device(s)"
         liftIO . mallocBytes $ sizeOf (undefined :: RawEvent)
 
   let cleanup :: LUIO m e => Ptr RawEvent -> m ()
       cleanup ptr = do
-        case prodStr of
-          Nothing -> logInfo "Closing HID devices"
-          Just s -> logInfo $ "Closing HID device: " <> s
-
+        logInfo "Closing HID device(s)"
         liftIO $ releaseKb >> free ptr
 
   let nextEvent :: IO m => Ptr RawEvent -> m KeySwitch

--- a/src/KMonad/App/Parser/Keycode.hs
+++ b/src/KMonad/App/Parser/Keycode.hs
@@ -99,9 +99,9 @@ manualAliases =
   , ("paus", ["pause", "KeyPause"])
   , ("cmps", ["compose", "cmp", "nUS\\", "KeyCompose"])
   , ("102d", ["102nd", "102", "lsgt", "nubs", "app", "Key102nd"])
-  , ("docs",  ["documents", "dcs", "KeyDocuments"])
-  , ("zenk", ["zenkaku", "KeyZenkakuHankaku", "zenkakuhankaku", "hank"])
-  , ("hang", ["hangeul", "hanguel", "KeyHangeul", "KeyHanguel"])
+--  , ("docs",  ["documents", "dcs", "KeyDocuments"])
+--  , ("zenk", ["zenkaku", "KeyZenkakuHankaku", "zenkakuhankaku", "hank"])
+--  , ("hang", ["hangeul", "hanguel", "KeyHangeul", "KeyHanguel"])
   ]
 
 -- | F11 and KeyF11 for f11 etc.

--- a/src/KMonad/App/Parser/TokenJoiner.hs
+++ b/src/KMonad/App/Parser/TokenJoiner.hs
@@ -74,7 +74,7 @@ instance Show JoinError where
     MissingSetting    t   -> "Missing setting in 'defcfg': "         <> T.unpack t
     DuplicateSetting  t   -> "Duplicate setting in 'defcfg': "       <> T.unpack t
     InvalidOS         t   -> "Not available under this OS: "         <> T.unpack t
-    NestedTrans           -> "Encountered 'Transparent' ouside of top-level layer"
+    NestedTrans           -> "Encountered 'Transparent' outside of top-level layer"
     InvalidComposeKey     -> "Encountered invalid button as Compose key"
     LengthMismatch t l s  -> mconcat
       [ "Mismatch between length of 'defsrc' and deflayer <", T.unpack t, ">\n"
@@ -230,7 +230,7 @@ getAllow = do
 
 pickInput :: IToken -> J KeyInputCfg
 pickInput (KDeviceSource f)     = pure $ LinuxEvdevCfg          $ EvdevCfg $ f
-pickInput (KIOKitSource n)      = pure $ MacIOKitCfg            $ IOKitCfg $ n
+pickInput (KIOKitSource dp)     = pure $ MacIOKitCfg            $ dp
 pickInput (KLowLevelHookSource) = pure $ WindowsLowLevelHookCfg $ LowLevelHookCfg
 
 pickOutput :: OToken -> J KeyOutputCfg
@@ -239,12 +239,12 @@ pickOutput (KUinputSink t init repcfg) = pure $ LinuxUinputCfg
         , _postInit     = unpack <$> init
         , _mayRepeatCfg = repcfg
         }
+pickOutput KExtSink       = pure $ MacExtCfg           $ ExtCfg
 -- FIXME: The following is ugly syntax
 pickOutput (KSendEventSink delay interval) = let
   d'  = maybe def (\dl -> def { _delay    = fi dl }) delay
   d'' = maybe d'  (\iv -> d'  { _interval = fi iv }) interval
   in pure $ WindowsSendEventCfg  $ SendEventCfg d''
-pickOutput KExtSink       = pure $ MacExtCfg           $ ExtCfg
 
 --------------------------------------------------------------------------------
 -- $als

--- a/src/KMonad/App/Parser/Tokenizer.hs
+++ b/src/KMonad/App/Parser/Tokenizer.hs
@@ -333,7 +333,9 @@ itokens :: [(Text, Parser IToken)]
 itokens =
   [ ("device-file"   , KDeviceSource <$> (T.unpack <$> textP))
   , ("low-level-hook", pure KLowLevelHookSource)
-  , ("iokit-name"    , KIOKitSource <$> optional textP)]
+  , ("iokit-name"    , KIOKitSource <$> optional (textP >>= mkCfg))]
+  where
+    mkCfg n = pure $ def {_cfgProductName = n}
 
 -- | Parse an output token
 otokenP :: Parser OToken

--- a/src/KMonad/App/Parser/Types.hs
+++ b/src/KMonad/App/Parser/Types.hs
@@ -162,7 +162,7 @@ data DefLayer = DefLayer
 data IToken
   = KDeviceSource FilePath
   | KLowLevelHookSource
-  | KIOKitSource (Maybe Text)
+  | KIOKitSource (Maybe IOKitCfg)
   deriving Show
 
 -- | All different output-tokens KMonad can take


### PR DESCRIPTION
- Mac: Support more identifiers for filtering devices
- Mac: list-keyboards: Print all available identifiers
- Mac: Change functions to accept `DeviceIdentifiers` record
- Something's wrong. Add tracing function.
- Mac: Fix for compilation errors.

**For some reason, this is not working when a product name is given in `iokit-name`. Need help!**

cc: @slotThe @thoelze1
