### PR TITLE
Document the "tap-macro-release" button.

### DIFF
--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -195,7 +195,8 @@ preferences—that's why there are so many! Particularly when using
 home-row modifiers, you will find some of the more crazy seeming buttons
 to be the most comfortable.
 
-+ `tap-macro`: take a sequence of keys and tap them
++ `tap-macro`: take a sequence of keys and tap them, but don’t release
+  the last key until the button is released.
 
   ```clojure
   (defalias ta1 (tap-macro K M o n a d))
@@ -209,6 +210,13 @@ to be the most comfortable.
     ta1 (tap-macro K M o n a d :delay 5)
     ;; equivalent to: (tap-macro K P5 M P5 o P5 n P5 a P5 d)
   )
+  ```
+
++ `tap-macro-release`: like `tap-macro` but don’t press the last key
+  until the button is released.
+
+  ```clojure
+  (defalias ta2 (tap-macro-release K M o n a d))
   ```
 
 + `multi-tap`: combine a sequence of keys into one key with a timeout

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -500,6 +500,13 @@
 
     (tap-macro K P5 M P5 o P5 n P5 a P5 d)
 
+  The `tap-macro-release` is like `tap-macro`, except that it
+  waits to press the last button when the `tap-macro-release`
+  gets released.  It might be useful when combined with a
+  footswitch that sends keybooard scan codes.
+
+    (tap-macro-release i K M o n a d esc)
+
   WARNING: DO NOT STORE YOUR PASSWORDS IN PLAIN TEXT OR IN YOUR KEYBOARD
 
   I know it might be tempting to store your password as a macro, but there are 2
@@ -520,11 +527,12 @@
   mc2 #(C-c P50 A-tab P50 C-v) ;; Careful, this might do something
   mc3 #(P200 h P150 4 P100 > < P50 > < P20 0 r z 1 ! 1 ! !)
   mc4 (tap-macro a (pause 50) @md2 (pause 50) c)
-  mc5 #(@mc3 spc @mc3 spc @mc3)
+  mc5 (tap-macro-release esc esc esc)
+  mc6 #(@mc3 spc @mc3 spc @mc3)
 )
 
 (deflayer macro-test
-  _    @mc1 @mc2 @mc3 @mc4 @mc5 _    _    _    _    _    _    _    _
+  _    @mc1 @mc2 @mc3 @mc4 @mc5 @mc6 _    _    _    _    _    _    _
   _    _    _    _    _    _    _    _    _    _    _    _    _    _
   _    _    _    _    _    _    _    _    _    _    _    _    _
   _    _    _    _    _    _    _    _    _    _    _    _


### PR DESCRIPTION
Resolves: Undocumented but useful "tap-macro-release" function. #525 

This button was undocumented, but I was looking for the functionality it provides in order to make use of a footswitch as a "Vim-clutch". There's more explanation in the linked issue.

Here, I added some description of the button to the reference doc and also some explanation and an example in the tutorial.

I tried to make these fit with the style of the existing texts. Thank you!