### PR TITLE
Feature/win key repeat

### DIFF
--- a/keymap/testing.kbd
+++ b/keymap/testing.kbd
@@ -1,0 +1,9 @@
+(defcfg
+  input (low-level-hook)
+  output (send-event-sink)
+)
+
+(defsrc q w e r t y lsft)
+
+(deflayer base
+  q w e r t y lsft)

--- a/keymap/testing.kbd
+++ b/keymap/testing.kbd
@@ -1,6 +1,6 @@
 (defcfg
   input (low-level-hook)
-  output (send-event-sink)
+  output (send-event-sink 1000 500)
 )
 
 (defsrc q w e r t y lsft)

--- a/keymap/testing.kbd
+++ b/keymap/testing.kbd
@@ -1,6 +1,6 @@
 (defcfg
   input (low-level-hook)
-  output (send-event-sink 1000 500)
+  output (send-event-sink 300 100)
 )
 
 (defsrc q w e r t y lsft)

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -260,7 +260,7 @@ pickOutput :: OToken -> J (LogFunc -> IO (Acquire KeySink))
 pickOutput (KUinputSink t init) = pure $ runLF (uinputSink cfg)
   where cfg = defUinputCfg { _keyboardName = T.unpack t
                            , _postInit     = T.unpack <$> init }
-pickOutput KSendEventSink       = throwError $ InvalidOS "SendEventSink"
+pickOutput (KSendEventSink _)   = throwError $ InvalidOS "SendEventSink"
 pickOutput KKextSink            = throwError $ InvalidOS "KextSink"
 
 #endif
@@ -275,9 +275,9 @@ pickInput (KIOKitSource _)    = throwError $ InvalidOS "IOKitSource"
 
 -- | The Windows correspondence between OToken and actual code
 pickOutput :: OToken -> J (LogFunc -> IO (Acquire KeySink))
-pickOutput KSendEventSink    = pure $ runLF sendEventKeySink
-pickOutput (KUinputSink _ _) = throwError $ InvalidOS "UinputSink"
-pickOutput KKextSink         = throwError $ InvalidOS "KextSink"
+pickOutput (KSendEventSink di) = pure $ runLF (sendEventKeySink di)
+pickOutput (KUinputSink _ _)   = throwError $ InvalidOS "UinputSink"
+pickOutput KKextSink           = throwError $ InvalidOS "KextSink"
 
 #endif
 
@@ -293,7 +293,7 @@ pickInput KLowLevelHookSource = throwError $ InvalidOS "LowLevelHookSource"
 pickOutput :: OToken -> J (LogFunc -> IO (Acquire KeySink))
 pickOutput KKextSink            = pure $ runLF kextSink
 pickOutput (KUinputSink _ _)    = throwError $ InvalidOS "UinputSink"
-pickOutput KSendEventSink       = throwError $ InvalidOS "SendEventSink"
+pickOutput (KSendEventSink _)   = throwError $ InvalidOS "SendEventSink"
 
 #endif
 

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -331,7 +331,7 @@ otokenP = choice $ map (try . uncurry statement) otokens
 otokens :: [(Text, Parser OToken)]
 otokens =
   [ ("uinput-sink"    , KUinputSink <$> lexeme textP <*> optional textP)
-  , ("send-event-sink", pure KSendEventSink)
+  , ("send-event-sink", KSendEventSink <$> lexeme (optional $ (,) <$> numP <*> numP))
   , ("kext"           , pure KKextSink)]
 
 -- | Parse the DefCfg token

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -331,7 +331,7 @@ otokenP = choice $ map (try . uncurry statement) otokens
 otokens :: [(Text, Parser OToken)]
 otokens =
   [ ("uinput-sink"    , KUinputSink <$> lexeme textP <*> optional textP)
-  , ("send-event-sink", KSendEventSink <$> lexeme (optional $ (,) <$> numP <*> numP))
+  , ("send-event-sink", KSendEventSink <$> (optional $ (,) <$> lexeme numP <*> numP))
   , ("kext"           , pure KKextSink)]
 
 -- | Parse the DefCfg token

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -167,7 +167,7 @@ data IToken
 -- | All different output-tokens KMonad can take
 data OToken
   = KUinputSink Text (Maybe Text)
-  | KSendEventSink
+  | KSendEventSink (Maybe (Int, Int))
   | KKextSink
   deriving Show
 

--- a/src/KMonad/Keyboard/IO/Windows/SendEventSink.hs
+++ b/src/KMonad/Keyboard/IO/Windows/SendEventSink.hs
@@ -45,7 +45,7 @@ makeClassy ''SKSink
 
 -- | Return a 'KeySink' using Window's @sendEvent@ functionality.
 sendEventKeySink :: HasLogFunc e => Maybe (Int, Int) -> RIO e (Acquire KeySink)
-sendEventKeySink di = mkKeySink (skOpen (fromMaybe (200, 100) di)) skClose skSend
+sendEventKeySink di = mkKeySink (skOpen (fromMaybe (300, 100) di)) skClose skSend
 
 -- | Create the 'SKSink' environment
 skOpen :: HasLogFunc e => (Int, Int) -> RIO e SKSink
@@ -54,7 +54,7 @@ skOpen (d, i) = do
   bv <- liftIO $ mallocBytes (sizeOf (undefined :: WinKeyEvent))
   bm <- newMVar bv
   r <- newMVar Nothing
-  pure $ SKSink bm r 100 100
+  pure $ SKSink bm r d i
 
 -- | Close the 'SKSink' environment
 skClose :: HasLogFunc e => SKSink -> RIO e ()

--- a/src/KMonad/Keyboard/IO/Windows/SendEventSink.hs
+++ b/src/KMonad/Keyboard/IO/Windows/SendEventSink.hs
@@ -84,8 +84,8 @@ skSend s e = do
         maybe (pure ()) cancel (r^?_Just._2)
         emit s w
         a <- async $ do
-          threadDelay (s^.delay)
-          forever $ emit s w >> threadDelay (s^.rate)
+          threadDelay (1000 * s^.delay)
+          forever $ emit s w >> threadDelay (1000 * s^.rate)
         pure $ Just (e^.keycode, a)
 
   -- When the event is a release

--- a/src/KMonad/Keyboard/IO/Windows/SendEventSink.hs
+++ b/src/KMonad/Keyboard/IO/Windows/SendEventSink.hs
@@ -44,12 +44,12 @@ data SKSink = SKSink
 makeClassy ''SKSink
 
 -- | Return a 'KeySink' using Window's @sendEvent@ functionality.
-sendEventKeySink :: HasLogFunc e => RIO e (Acquire KeySink)
-sendEventKeySink = mkKeySink skOpen skClose skSend
+sendEventKeySink :: HasLogFunc e => Maybe (Int, Int) -> RIO e (Acquire KeySink)
+sendEventKeySink di = mkKeySink (skOpen (fromMaybe (200, 100) di)) skClose skSend
 
 -- | Create the 'SKSink' environment
-skOpen :: HasLogFunc e => RIO e SKSink
-skOpen = do
+skOpen :: HasLogFunc e => (Int, Int) -> RIO e SKSink
+skOpen (d, i) = do
   logInfo "Initializing Windows key sink"
   bv <- liftIO $ mallocBytes (sizeOf (undefined :: WinKeyEvent))
   bm <- newMVar bv


### PR DESCRIPTION
I think I have this working now. The way it's currently implemented, you may optionally provide 2 arguments to `send-event-sink` (it's optional whether you provide them, but when you provide them you must provide 2) that determine the `delay` and the `rate` of the key repeat.
`delay` - How many ms before a key starts repeating
`rate` - How many ms between each repeat event

I only have Windows running in a VirtualBox, so my testing setup is very limited. Let's try to get some people to try it and if nothing blows up we merge this in?

