### PR TITLE
Feature/gestures

### DIFF
--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -39,6 +39,7 @@ library
   build-depends:
       base
     , cereal
+    -- , hspec
     , lens
     , megaparsec
     , mtl
@@ -71,6 +72,12 @@ library
       KMonad.App
       KMonad.App.Main
       KMonad.App.Types
+      KMonad.Args
+      KMonad.Args.Cmd
+      KMonad.Args.Parser
+      KMonad.Args.Joiner
+      KMonad.Args.TH
+      KMonad.Args.Types
       KMonad.Model
       KMonad.Model.Action
       KMonad.Model.BEnv
@@ -79,18 +86,14 @@ library
       KMonad.Model.Hooks
       KMonad.Model.Keymap
       KMonad.Model.Sluice
-      KMonad.Args
-      KMonad.Args.Cmd
-      KMonad.Args.Parser
-      KMonad.Args.Joiner
-      KMonad.Args.TH
-      KMonad.Args.Types
+      KMonad.Gesture
       KMonad.Keyboard
       KMonad.Keyboard.ComposeSeq
       KMonad.Keyboard.IO
       KMonad.Keyboard.Keycode
       KMonad.Keyboard.Ops
       KMonad.Keyboard.Types
+      KMonad.Parsing
       KMonad.Prelude
       KMonad.Prelude.Imports
       KMonad.Prelude.Definitions
@@ -156,3 +159,38 @@ executable kmonad
   build-depends:
       base
     , kmonad
+
+test-suite spec
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+      test
+  ghc-options:
+      -Wall
+  build-depends:
+      base
+    , kmonad
+    , hspec
+  other-modules:
+      KMonad.GestureSpec
+  default-language:
+      Haskell2010
+  build-tool-depends: hspec-discover:hspec-discover == 2.*
+  default-extensions:
+      ConstraintKinds
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NoImplicitPrelude
+      OverloadedStrings
+      RankNTypes
+      TemplateHaskell
+      TupleSections
+      TypeFamilies

--- a/src/KMonad/Args.hs
+++ b/src/KMonad/Args.hs
@@ -27,7 +27,7 @@ import KMonad.Args.Types
 loadConfig :: HasLogFunc e => Cmd -> RIO e AppCfg
 loadConfig cmd = do
 
-  tks <- loadTokens (cmd^.cfgFile)      -- This can throw a PErrors
+  tks <- loadTokens (cmd^.cfgFile)      -- This can throw a ParseError
   cgt <- joinConfigIO (joinCLI cmd tks) -- This can throw a JoinError
 
   -- Try loading the sink and src

--- a/src/KMonad/Args/Cmd.hs
+++ b/src/KMonad/Args/Cmd.hs
@@ -19,11 +19,11 @@ where
 import KMonad.Prelude hiding (try)
 import KMonad.Args.Parser (itokens, keywordButtons, noKeywordButtons, otokens, symbol, numP)
 import KMonad.Args.TH (gitHash)
-import KMonad.Args.Types (DefSetting(..), choice, try)
+import KMonad.Args.Types (DefSetting(..))
 import KMonad.Util
 import Paths_kmonad (version)
 
-import qualified KMonad.Args.Types as M  -- [M]egaparsec functionality
+import qualified KMonad.Parsing as M  -- [M]egaparsec functionality
 
 import Data.Version (showVersion)
 import Options.Applicative
@@ -143,7 +143,7 @@ initStrP = optional $ SInitStr <$> strOption
 -- | Key to use for compose-key sequences
 cmpSeqP :: Parser (Maybe DefSetting)
 cmpSeqP = optional $ SCmpSeq <$> option
-  (tokenParser keywordButtons <|> megaReadM (choice noKeywordButtons))
+  (tokenParser keywordButtons <|> megaReadM (M.choice noKeywordButtons))
   (  long "cmp-seq"
   <> short 's'
   <> metavar "BUTTON"
@@ -180,7 +180,7 @@ startDelayP = option (fromIntegral <$> megaReadM numP)
 -- | Transform a bunch of tokens of the form @(Keyword, Parser)@ into an
 -- optparse-applicative parser
 tokenParser :: [(Text, M.Parser a)] -> ReadM a
-tokenParser = megaReadM . choice . map (try . uncurry ((*>) . symbol))
+tokenParser = megaReadM . M.choice . map (M.try . uncurry ((*>) . symbol))
 
 -- | Megaparsec <--> optparse-applicative interface
 megaReadM :: M.Parser a -> ReadM a

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -34,9 +34,12 @@ where
 
 import KMonad.Prelude hiding (try, bool)
 
+import KMonad.Parsing
 import KMonad.Args.Types
 import KMonad.Keyboard
 import KMonad.Keyboard.ComposeSeq
+
+
 
 import Data.Char
 import RIO.List (sortBy, find)
@@ -51,9 +54,9 @@ import qualified Text.Megaparsec.Char.Lexer as L
 -- $run
 
 -- | Try to parse a list of 'KExpr' from 'Text'
-parseTokens :: Text -> Either PErrors [KExpr]
+parseTokens :: Text -> Either ParseError [KExpr]
 parseTokens t = case runParser configP "" t  of
-  Left  e -> Left $ PErrors e
+  Left  e -> Left $ ParseError e
   Right x -> Right x
 
 -- | Load a set of tokens from file, throw an error on parse-fail
@@ -65,13 +68,6 @@ loadTokens pth = parseTokens <$> readFileUtf8 pth >>= \case
 
 --------------------------------------------------------------------------------
 -- $basic
-
--- | Consume whitespace
-sc :: Parser ()
-sc = L.space
-  space1
-  (L.skipLineComment  ";;")
-  (L.skipBlockComment "#|" "|#")
 
 -- | Consume whitespace after the provided parser
 lexeme :: Parser a -> Parser a

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -10,12 +10,9 @@ Portability : non-portable (MPTC with FD, FFI to Linux-only c-code)
 
 -}
 module KMonad.Args.Types
-  ( -- * $bsc
-    Parser
-  , PErrors(..)
-
+  (
     -- * $cfg
-  , CfgToken(..)
+    CfgToken(..)
 
     -- * $but
   , DefButton(..)
@@ -35,10 +32,6 @@ module KMonad.Args.Types
     -- * $lenses
   , AsKExpr(..)
   , AsDefSetting(..)
-
-    -- * Reexports
-  , module Text.Megaparsec
-  , module Text.Megaparsec.Char
 ) where
 
 
@@ -48,25 +41,6 @@ import KMonad.Model.Button
 import KMonad.Keyboard
 import KMonad.Keyboard.IO
 import KMonad.Util
-
-import Text.Megaparsec
-import Text.Megaparsec.Char
-
---------------------------------------------------------------------------------
--- $bsc
---
--- The basic types of parsing
-
--- | Parser's operate on Text and carry no state
-type Parser = Parsec Void Text
-
--- | The type of errors returned by the Megaparsec parsers
-newtype PErrors = PErrors (ParseErrorBundle Text Void)
-
-instance Show PErrors where
-  show (PErrors e) = "Parse error at " <> errorBundlePretty e
-
-instance Exception PErrors
 
 --------------------------------------------------------------------------------
 -- $but

--- a/src/KMonad/Gesture.hs
+++ b/src/KMonad/Gesture.hs
@@ -1,0 +1,171 @@
+-- |
+
+module KMonad.Gesture
+
+where
+
+
+import KMonad.Prelude hiding (try)
+
+import System.IO
+
+import Control.Arrow (right)
+import Control.Monad.Except
+import Control.Monad.State
+
+import RIO.List.Partial (head)
+import RIO.Seq (Seq(..))
+
+import qualified RIO.List as L
+import qualified RIO.Seq  as Q
+import qualified RIO.Set  as S
+
+import Data.Char
+
+import Text.Megaparsec hiding (State)
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as X
+
+
+
+--------------------------------------------------------------------------------
+
+data Toggle a = On a | Off a deriving (Eq, Show, Functor)
+
+code :: Lens' (Toggle a) a
+code = lens get set
+  where get (On x)    = x
+        get (Off x)   = x
+        set (On _) x  = On x
+        set (Off _) x = Off x
+
+newtype Gesture a = Gesture { _gesture :: Q.Seq (Toggle a) }
+  deriving (Eq, Show, Functor)
+
+instance Semigroup (Gesture a) where
+  (Gesture a) <> (Gesture b) = Gesture $ a <> b
+instance Monoid (Gesture a) where
+  mempty = Gesture $ Q.empty
+
+-- | A fold of all the unique elements in a gesture
+--
+-- NOTE: Non-optimized non-bottleneck
+elems :: Ord a => Fold (Gesture a) a
+elems = folding $ \(Gesture as) -> toList . S.fromList $ as^..folded.code
+
+-- | All the ways a '[Toggle a]' can be an invalid 'Gesture'
+data GestureError a
+  = OffWithoutOn a -- ^ An Off not preceded by an On
+  | OnWithoutOff a -- ^ An On not succeeded by an Off
+  deriving (Eq, Show)
+
+-- | Create a tapping gesture
+tap :: a -> Gesture a
+tap a = Gesture . Q.fromList $ [On a, Off a]
+
+-- | Wrap a gesture in a toggle iff the id does not already occur
+around :: Ord a => a -> Gesture a -> Either (GestureError a) (Gesture a)
+around x g@(Gesture seq)
+  | anyOf elems (== x) g = Left $ OnWithoutOff x
+  | otherwise = Right . Gesture $ (On x <| seq) |> Off x
+
+-- | Create a gesture from a list of toggles
+fromList :: Ord a => [Toggle a] -> Either (GestureError a) (Gesture a)
+fromList as = case (`runState` S.empty) . runExceptT . foldM f Q.empty $ as of
+  (Left e, _) -> Left e
+  (Right g, s) | S.null s -> Right $ Gesture g
+               | otherwise -> Left $ OnWithoutOff (head . S.elems $ s)
+  where
+    f s x = do
+      pressed <- get
+      case x of
+        On c  | c `S.member` pressed -> throwError $ OnWithoutOff c
+        On c -> put (S.insert c pressed) >> pure (s |> On c)
+        Off c | not (c `S.member` pressed) -> throwError $ OffWithoutOn c
+        Off c -> put (S.delete c pressed) >> pure (s |> Off c)
+
+
+foo, bar, baz, bop, bup :: Either (GestureError Int) (Gesture Int)
+foo = fromList $ [On 1, On 2, Off 1, Off 2]
+bar = fromList $ [Off 3, On 1, On 2, Off 1, Off 2]
+baz = fromList $ [On 1, On 2, Off 1]
+bop = fromList $ [On 1, On 1, Off 1]
+bup = fromList $ [On 1, Off 1, Off 1]
+
+--------------------------------------------------------------------------------
+
+{-
+"a b c"
+"S-a"
+"S-(a b c)-S"
+-}
+
+-- CONTINUE HERE
+newtype ParseErrorG = ParseErrorG { _gbundle :: ParseErrorBundle }
+
+type G a = ExceptT
+
+type Parser = Parsec Void Text
+type Gest = Q.Seq (Toggle Text)
+
+readGesture :: Text -> Maybe (Gesture Text)
+readGesture t = case runParser gest "" t of
+  Left _ -> Nothing
+  Right gs ->
+  either (const Nothing) Just . right fromList .
+
+parseG :: Show a => Parser a -> Text -> IO ()
+parseG a t = case runParser a "" t of
+  Left perr -> putStr (errorBundlePretty perr)
+  Right x   -> print x
+
+reserved :: [Char]
+reserved = "()-~[]"
+
+sc :: Parser ()
+sc = X.space space1 empty empty
+
+lex :: Parser a -> Parser a
+lex = X.lexeme sc
+
+tag :: Parser Text
+tag = takeWhile1P (Just "tag-character") f
+  where f c = not $ isSpace c || c `elem` reserved
+
+around_ :: Parser Gest
+around_ = do
+  a <- tag
+  _ <- char '-'
+  b <- try around_ <|> subg <|> tap_
+
+  pure $ (On a <| b) |> Off a
+
+closeTag :: Parser Gest
+closeTag = do
+  _ <- string ")-"
+  a <- tag
+  pure . Q.singleton $ Off a
+
+openTag :: Parser Gest
+openTag = do
+  a <- tag
+  _ <- string "-("
+  pure . Q.singleton $ On a
+
+tap_ :: Parser Gest
+tap_ = do
+  a <- tag
+  pure . Q.fromList $ [On a, Off a]
+
+subg :: Parser Gest
+subg = do
+  _ <- char '['
+  g <- gest
+  _ <- char ']'
+  pure g
+
+gest :: Parser Gest
+gest = do
+  let one = lex . choice $ [subg, try openTag, try around_, try closeTag, tap_]
+  es <- some one
+  pure $ mconcat es

--- a/src/KMonad/Gesture.hs
+++ b/src/KMonad/Gesture.hs
@@ -4,14 +4,12 @@ module KMonad.Gesture
 
 where
 
-
 import KMonad.Prelude hiding (try)
+import KMonad.Parsing
 
-import System.IO
-
-import Control.Arrow (right)
 import Control.Monad.Except
 import Control.Monad.State
+import Data.Char
 
 import RIO.List.Partial (head)
 import RIO.Seq (Seq(..))
@@ -20,44 +18,40 @@ import qualified RIO.List as L
 import qualified RIO.Seq  as Q
 import qualified RIO.Set  as S
 
-import Data.Char
-
-import Text.Megaparsec hiding (State)
-import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as X
-
-
 
 --------------------------------------------------------------------------------
 
 data Toggle a = On a | Off a deriving (Eq, Show, Functor)
 
-code :: Lens' (Toggle a) a
-code = lens get set
-  where get (On x)    = x
-        get (Off x)   = x
-        set (On _) x  = On x
-        set (Off _) x = Off x
-
+-- | A sequence of toggle-changes guaranteed to be valid
 newtype Gesture a = Gesture { _gesture :: Q.Seq (Toggle a) }
   deriving (Eq, Show, Functor)
 
 instance Semigroup (Gesture a) where
   (Gesture a) <> (Gesture b) = Gesture $ a <> b
 instance Monoid (Gesture a) where
-  mempty = Gesture $ Q.empty
-
--- | A fold of all the unique elements in a gesture
---
--- NOTE: Non-optimized non-bottleneck
-elems :: Ord a => Fold (Gesture a) a
-elems = folding $ \(Gesture as) -> toList . S.fromList $ as^..folded.code
+  mempty = Gesture Q.empty
 
 -- | All the ways a '[Toggle a]' can be an invalid 'Gesture'
 data GestureError a
   = OffWithoutOn a -- ^ An Off not preceded by an On
   | OnWithoutOff a -- ^ An On not succeeded by an Off
   deriving (Eq, Show)
+
+
+--------------------------------------------------------------------------------
+
+-- | A lens into the i
+tag :: Lens' (Toggle a) a
+tag = lens get set
+  where get (On x)    = x
+        get (Off x)   = x
+        set (On _) x  = On x
+        set (Off _) x = Off x
+
+-- | A fold of all the unique elements in a gesture
+tags :: Ord a => Fold (Gesture a) a
+tags = folding $ \(Gesture as) -> toList . S.fromList $ as^..folded.tag
 
 -- | Create a tapping gesture
 tap :: a -> Gesture a
@@ -66,7 +60,7 @@ tap a = Gesture . Q.fromList $ [On a, Off a]
 -- | Wrap a gesture in a toggle iff the id does not already occur
 around :: Ord a => a -> Gesture a -> Either (GestureError a) (Gesture a)
 around x g@(Gesture seq)
-  | anyOf elems (== x) g = Left $ OnWithoutOff x
+  | anyOf tags (== x) g = Left $ OnWithoutOff x
   | otherwise = Right . Gesture $ (On x <| seq) |> Off x
 
 -- | Create a gesture from a list of toggles
@@ -84,79 +78,67 @@ fromList as = case (`runState` S.empty) . runExceptT . foldM f Q.empty $ as of
         Off c | not (c `S.member` pressed) -> throwError $ OffWithoutOn c
         Off c -> put (S.delete c pressed) >> pure (s |> Off c)
 
-
-foo, bar, baz, bop, bup :: Either (GestureError Int) (Gesture Int)
-foo = fromList $ [On 1, On 2, Off 1, Off 2]
-bar = fromList $ [Off 3, On 1, On 2, Off 1, Off 2]
-baz = fromList $ [On 1, On 2, Off 1]
-bop = fromList $ [On 1, On 1, Off 1]
-bup = fromList $ [On 1, Off 1, Off 1]
-
 --------------------------------------------------------------------------------
 
-{-
-"a b c"
-"S-a"
-"S-(a b c)-S"
--}
-
--- CONTINUE HERE
-newtype ParseErrorG = ParseErrorG { _gbundle :: ParseErrorBundle }
-
-type G a = ExceptT
-
-type Parser = Parsec Void Text
 type Gest = Q.Seq (Toggle Text)
 
-readGesture :: Text -> Maybe (Gesture Text)
-readGesture t = case runParser gest "" t of
-  Left _ -> Nothing
-  Right gs ->
-  either (const Nothing) Just . right fromList .
+data GestureReadError
+  = GestureParseError ParseError
+  | GestureValidateError (GestureError Text)
+  deriving Eq
 
-parseG :: Show a => Parser a -> Text -> IO ()
-parseG a t = case runParser a "" t of
-  Left perr -> putStr (errorBundlePretty perr)
-  Right x   -> print x
+instance Show GestureReadError where
+  show (GestureParseError e) = show e
+  show (GestureValidateError e) = show e
 
+instance Exception GestureReadError
+
+-- | Parse a Gesture straight from Text
+prsGesture :: Text -> Either GestureReadError (Gesture Text)
+prsGesture t = case runParser gest "" t of
+  Left e -> Left . GestureParseError . ParseError $ e
+  Right gs -> case fromList (toList gs) of
+    Left e -> Left . GestureValidateError $ e
+    Right g -> pure g
+
+-- | Characters that may not occur in tag-names
 reserved :: [Char]
 reserved = "()-~[]"
 
-sc :: Parser ()
-sc = X.space space1 empty empty
-
-lex :: Parser a -> Parser a
-lex = X.lexeme sc
-
-tag :: Parser Text
-tag = takeWhile1P (Just "tag-character") f
+-- | Parse a series of valid characters as a tag
+tag_ :: Parser Text
+tag_ = takeWhile1P (Just "tag-character") f
   where f c = not $ isSpace c || c `elem` reserved
 
+-- | Parse a "S-" sequence as 1 tag around another
 around_ :: Parser Gest
 around_ = do
-  a <- tag
+  a <- tag_
   _ <- char '-'
   b <- try around_ <|> subg <|> tap_
-
   pure $ (On a <| b) |> Off a
 
+-- | Parse a ")-X" as an OFF-toggle
 closeTag :: Parser Gest
 closeTag = do
   _ <- string ")-"
-  a <- tag
+  a <- tag_
   pure . Q.singleton $ Off a
 
+-- | Parse a "X-(" as an ON-toggle
 openTag :: Parser Gest
 openTag = do
-  a <- tag
+  a <- tag_
   _ <- string "-("
   pure . Q.singleton $ On a
 
+-- | Parse only a tag as a tap of that element
 tap_ :: Parser Gest
 tap_ = do
-  a <- tag
+  a <- tag_
   pure . Q.fromList $ [On a, Off a]
 
+-- | Parse a [] delimited series as a nested gesture
 subg :: Parser Gest
 subg = do
   _ <- char '['
@@ -164,6 +146,7 @@ subg = do
   _ <- char ']'
   pure g
 
+-- | Parse a full gesture
 gest :: Parser Gest
 gest = do
   let one = lex . choice $ [subg, try openTag, try around_, try closeTag, tap_]

--- a/src/KMonad/Parsing.hs
+++ b/src/KMonad/Parsing.hs
@@ -1,0 +1,57 @@
+-- | A collection of general parsing definitions
+
+module KMonad.Parsing
+  ( Parser
+  , ParserT
+  , ParseError(..)
+
+  , sc
+  , hsc
+  , lex
+  , hlex
+
+  , module Text.Megaparsec
+  , module Text.Megaparsec.Char
+  )
+
+where
+
+import KMonad.Prelude
+
+import Text.Megaparsec hiding (ParseError)
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as X
+
+
+--------------------------------------------------------------------------------
+
+-- | Parsec type specified down to Void Text
+type Parser a    = Parsec Void Text a
+type ParserT m a = ParsecT Void Text m a
+
+-- | Parsec parse errors under Void Text with an Exception instance
+newtype ParseError = ParseError { _parseError :: ParseErrorBundle Text Void}
+  deriving Eq
+
+instance Show ParseError where
+  show (ParseError e) = "Parse error at " <> errorBundlePretty e
+
+instance Exception ParseError
+
+--------------------------------------------------------------------------------
+
+-- | Horizontal space consumption
+hsc :: Parser ()
+hsc = X.space space1 empty empty
+
+-- | Horizontal space lexeme
+hlex :: Parser a -> Parser a
+hlex = X.lexeme hsc
+
+-- | Full space consumption
+sc :: Parser ()
+sc = X.space space1 (X.skipLineComment  ";;") (X.skipBlockComment "#|" "|#")
+
+-- | Full space lexeme
+lex :: Parser a -> Parser a
+lex = X.lexeme sc

--- a/src/KMonad/Prelude/Definitions.hs
+++ b/src/KMonad/Prelude/Definitions.hs
@@ -3,3 +3,5 @@
 module KMonad.Prelude.Definitions
   ( )
 where
+
+import KMonad.Prelude.Imports

--- a/test/KMonad/GestureSpec.hs
+++ b/test/KMonad/GestureSpec.hs
@@ -1,0 +1,39 @@
+module KMonad.GestureSpec ( spec ) where
+
+import KMonad.Prelude
+import KMonad.Gesture
+
+import Test.Hspec hiding (around)
+
+r :: Either a b -> b
+r = fromRight undefined
+
+spec :: Spec
+spec = do
+
+  let abc  = tap "a" <> tap "b" <> tap "c"
+  let sa   = r $ around "S" (tap "a")
+  let csa  = r $ around "C" sa
+  let c    = tap "C"
+  let sabc = r $ around "S" abc
+  let xx   = r $ around "C" (sa <> tap "b")
+
+  describe "gesture" $ do
+
+    it "parses \"a b c\" as series of taps" $ do
+      prsGesture "a b c" `shouldBe` Right abc
+
+    it "parses \"S-a\" as S held around tap of a" $ do
+      prsGesture "S-a" `shouldBe` Right sa
+
+    it "parses \"C-S-a\" as C around S around a" $ do
+      prsGesture "C-S-a" `shouldBe` Right csa
+
+    it "parses \"C-(  )-C\" as the press and release of C" $ do
+      prsGesture "C-( )-C" `shouldBe` Right c
+
+    it "parser \"C-(S-a b)-C\" as C around shifted-a b" $ do
+      prsGesture "C-(S-a b)-C" `shouldBe` Right xx
+
+    it "parses \"S-[a b c]\" as S around taps of a b c" $ do
+      prsGesture "S-[a b c]" `shouldBe` Right sabc

--- a/test/KMonad/GestureSpec.hs
+++ b/test/KMonad/GestureSpec.hs
@@ -3,6 +3,8 @@ module KMonad.GestureSpec ( spec ) where
 import KMonad.Prelude
 import KMonad.Gesture
 
+import Data.Either (fromRight)
+
 import Test.Hspec hiding (around)
 
 r :: Either a b -> b

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
I wanted to redo keycode representations,
- but its semantics leaked into the parser

I wanted to redo the parser
- but its semantics leaked into the invocation

I wanted to redo the invocation
- but its semantics leaked into the app-loop-configuration

I wanted to redo the app-loop-configuration
- but I was lacking a way to easily express compound keyboard actions.

This feature branch fixes that by introducing a small DSL for 'gestures', sequences of key events that are guaranteed to be valid (i.e. no pressing of already pressed keys, no releasing a key before it's been pressed, etc), plus a mini-language so that people can express all possible (I think..) gestures.

Also, I copied over some of the testing-framework from keycode-refactor into master and wrote a few tests for Gestures. 

This is basically ready to merge, and I was about to push it straight to master, but then I remembered that the better part of valour is discretion. So, any issues/critiques? 