### PR TITLE
Bump compiler version in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lierdakil/alpine-haskell:8.10.4
+FROM lierdakil/alpine-haskell:8.10.7
 
 WORKDIR /usr/src/kmonad/
 RUN apk --no-cache add git


### PR DESCRIPTION
Stack.yaml was updated to lts-18.27 resolver, which uses GHC 8.10.7;
the Dockerfile wasn't updated accordingly, though.