### PR TITLE
nixos-module: use submodule name as keyboard name by default

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -9,6 +9,7 @@ let
       name = lib.mkOption {
         type = lib.types.str;
         example = "laptop-internal";
+        default = name;
         description = "Keyboard name.";
       };
 


### PR DESCRIPTION
This will make using
```nix
keyboards = {
  internal-keyboard = {
    name = "internal-keyboard"; # optional now
    ...
  };
};
```
optional. Tested on my configuration.