### PR TITLE
A sketch of how general Unicode could be handled on Linux.

### DIFF
--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -32,6 +32,8 @@ import KMonad.Model.Action
 import KMonad.Model.Button
 import KMonad.Keyboard
 import KMonad.Keyboard.IO
+import KMonad.Parsing (runParser, some)
+import KMonad.Args.Parser (buttonP)
 
 #ifdef linux_HOST_OS
 import KMonad.Keyboard.IO.Linux.DeviceSource
@@ -49,6 +51,7 @@ import KMonad.Keyboard.IO.Mac.KextSink
 #endif
 
 import Control.Monad.Except
+import Numeric (showHex)
 
 import RIO.List (headMaybe, intersperse, uncons)
 import RIO.Partial (fromJust)
@@ -364,6 +367,12 @@ joinButton ns als =
     KComposeSeq bs     -> do csd <- getCmpSeqDelay
                              c   <- view cmpKey
                              jst $ tapMacro . (c:) <$> isps bs csd
+    KUnicodeChar cb    -> do csd <- getCmpSeqDelay
+                             -- c   <- view unicodeKey
+                             let uniInputKeys = T.pack
+                                  $ "C-S-u " ++ intersperse ' ' (showHex (fromEnum cb) "") ++ " spc"
+                             case runParser (some buttonP) "" uniInputKeys of
+                               Right bs -> jst $ tapMacro <$> isps bs csd
     KTapMacro bs mbD   -> jst $ tapMacro           <$> isps bs mbD
     KTapMacroRelease bs mbD ->
       jst $ tapMacroRelease           <$> isps bs mbD

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -77,6 +77,7 @@ data DefButton
   | KTapMacroRelease [DefButton] (Maybe Int)
     -- ^ Sequence of buttons to tap, tap last on release, possible delay between each press
   | KComposeSeq [DefButton]                -- ^ Compose-key sequence
+  | KUnicodeChar Char                      -- ^ Compose-key sequence
   | KPause Milliseconds                    -- ^ Pause for a period of time
   | KLayerDelay Int LayerTag               -- ^ Switch to a layer for a period of time
   | KLayerNext LayerTag                    -- ^ Perform next button in different layer


### PR DESCRIPTION
This uses the fact that at least on X11, characters can be specified by ctrl+shift+U followed by the hexadecimal representation of the Unicode code point.

The implementation is a big hack, but could be generalised to something that allows specifying different way to deal with Unicode in the `defcfg`.

IMO something general like this is much preferrable to the current detour via Compose key seqs. After all, that's basically using another configurable keyboard remapper to make up for the shortcomings of this configurable keyboard mapper...
Also, better Unicode support seems to be much requested in the issues.