### PR TITLE
Support x86_64-darwin in flake

### DIFF
--- a/c_src/mac/.gitignore
+++ b/c_src/mac/.gitignore
@@ -1,0 +1,1 @@
+list-keyboards

--- a/c_src/mac/Makefile
+++ b/c_src/mac/Makefile
@@ -1,2 +1,10 @@
-all: list-keyboards.c
-	gcc $< -o list-keyboards -framework IOKit -framework CoreFoundation
+.PHONY: all install
+
+all: list-keyboards
+
+install: list-keyboards
+	mkdir -p $(DESTDIR)/bin
+	cp $< $(DESTDIR)/bin
+
+list-keyboards: list-keyboards.c
+	$(CC) $< -o $@ -framework IOKit -framework CoreFoundation

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -58,6 +58,18 @@ because you installed it yourself or because you are using NixOS, you can build
 nix-build nix
 ```
 
+On MacOS, you'll have to use something like the following to get nix to pull in
+the karabiner submodule:
+
+```shell
+nix build "./nix?submodules=1"
+```
+
+If you want to pull in kmonad as a flake input for configuring a darwin system,
+you may find it necessary to use a reference like:
+`git+https://github.com/kmonad/kmonad?submodules=1&dir=nix` instead of
+`github:...`.
+
 Another option with `nix` is to use the `nix-shell` to ensure you have the
 correct environment to run `stack` in. You can enter the development environment
 using:
@@ -65,7 +77,6 @@ using:
 ```shell
 nix-shell nix/shell.nix
 ```
-
 
 Note: we do also have to compile a little bit of C-code, so make sure `gcc` is
 installed as well.

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -8,7 +8,12 @@
   outputs = { self, nixpkgs, ... }@inputs:
     let
       # List of supported systems:
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
 
       # List of supported compilers:
       supportedCompilers = [

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -74,7 +74,18 @@
           # Just the executables for the default compiler:
           default = pkgs.haskell.lib.justStaticExecutables
             (derivation pkgs pkgs.haskellPackages);
-        } // builtins.listToAttrs (map
+        } // (pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+          list-keyboards = pkgs.stdenv.mkDerivation {
+            name = "list-keyboards";
+            version = self.shortRev;
+            src = ../c_src/mac;
+            buildInputs = [
+              pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+              pkgs.darwin.IOKit
+            ];
+            installFlags = [ "DESTDIR=$(out)" ];
+          };
+        }) // builtins.listToAttrs (map
           (compiler: {
             name = "kmonad-${compiler}";
             value = derivation pkgs pkgs.haskell.packages.${compiler};

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -62,6 +62,13 @@
           "--extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include"
           "--extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit"
         ];
+        statSubmodulePhase = ''
+          stat c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include || (
+            echo "Karabiner submodule not found. This flake needs to be built with submodules on darwin. See the kmonad docs for more information." 1>&2
+            exit 1
+          )
+        '';
+        preConfigurePhases = [ "statSubmodulePhase" ] ++ orig.preConfigurePhases;
       }));
     in
     {


### PR DESCRIPTION
This pull request adds support for the `x86_64-darwin` system to the flake, as well as a `list-keyboards` package for that platform. It does the same thing as https://github.com/kmonad/kmonad/pull/566 except for master.