### PR TITLE
Read from multiple inputs

### DIFF
--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -251,7 +251,7 @@ getCmpSeqDelay = do
 
 -- | The Linux correspondence between IToken and actual code
 pickInput :: IToken -> J (LogFunc -> IO (Acquire KeySource))
-pickInput (KDeviceSource f)   = pure $ runLF (deviceSource64 f)
+pickInput (KDeviceSource f)   = pure $ runLF (deviceSourceMultiple64 f)
 pickInput KLowLevelHookSource = throwError $ InvalidOS "LowLevelHookSource"
 pickInput (KIOKitSource _)    = throwError $ InvalidOS "IOKitSource"
 

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -322,7 +322,7 @@ itokenP = choice $ map (try . uncurry statement) itokens
 -- | Input tokens to parse; the format is @(keyword, how to parse the token)@
 itokens :: [(Text, Parser IToken)]
 itokens =
-  [ ("device-file"   , KDeviceSource <$> (T.unpack <$> textP))
+  [ ("device-file"   , KDeviceSource <$> (some (T.unpack <$> textP)))
   , ("low-level-hook", pure KLowLevelHookSource)
   , ("iokit-name"    , KIOKitSource <$> optional textP)]
 

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -136,7 +136,7 @@ data DefLayer = DefLayer
 
 -- | All different input-tokens KMonad can take
 data IToken
-  = KDeviceSource FilePath
+  = KDeviceSource [FilePath]
   | KLowLevelHookSource
   | KIOKitSource (Maybe Text)
   deriving Show

--- a/src/KMonad/Keyboard/IO.hs
+++ b/src/KMonad/Keyboard/IO.hs
@@ -66,9 +66,9 @@ newtype KeySource = KeySource { awaitKeyWith :: IO KeyEvent}
 
 -- | Create a new KeySource
 mkKeySource :: HasLogFunc e
-  => RIO e src               -- ^ Action to acquire the keysink
-  -> (src -> RIO e ())       -- ^ Action to close the keysink
-  -> (src -> RIO e KeyEvent) -- ^ Action to write with the keysink
+  => RIO e src               -- ^ Action to acquire the keysource
+  -> (src -> RIO e ())       -- ^ Action to close the keysource
+  -> (src -> RIO e KeyEvent) -- ^ Action to read from the keysource
   -> RIO e (Acquire KeySource)
 mkKeySource o c r = do
   u <- askUnliftIO

--- a/src/KMonad/Keyboard/IO/Linux/DeviceSource.hs
+++ b/src/KMonad/Keyboard/IO/Linux/DeviceSource.hs
@@ -13,6 +13,7 @@ Portability : portable
 module KMonad.Keyboard.IO.Linux.DeviceSource
   ( deviceSource
   , deviceSource64
+  , deviceSourceMultiple64
 
   , KeyEventParser
   , decode64

--- a/src/KMonad/Keyboard/IO/Linux/DeviceSource.hs
+++ b/src/KMonad/Keyboard/IO/Linux/DeviceSource.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-|
 Module      : KMonad.Keyboard.IO.Linux.DeviceSource
 Description : Load and acquire a linux /dev/input device
@@ -119,6 +120,50 @@ deviceSource64 :: HasLogFunc e
   -> RIO e (Acquire KeySource)
 deviceSource64 = deviceSource defEventParser
 
+-- | Open multiple device files
+deviceSourceMultiple :: HasLogFunc e
+  => KeyEventParser -- ^ The method by which to read and decode events
+  -> [FilePath]     -- ^ The filepath to the device file
+  -> RIO e (Acquire KeySource)
+deviceSourceMultiple pr pts = mkKeySource open close read
+  where
+
+    open = do
+      -- TODO: if one lsOpen fails, the previous ones won't be closed.
+      --       we should do the open/close with bracket inside the reader.
+      handles <- traverse (lsOpen pr) pts
+      chan <- newTChanIO
+      readers <- traverse (\src -> async (keepReadingInto chan src)) handles
+      return (handles, chan, readers)
+
+    close (handles, _chan, readers) = do
+      traverse_ cancel readers
+      traverse_ lsClose handles
+
+    read (_, chan, _) = do
+      item <- atomically $ readTChan chan
+      case item of
+        Right ev -> return ev
+        Left ex -> throwIO ex
+
+    lsReadInto chan src = do
+      ev <- lsRead src
+      atomically $ writeTChan chan (Right ev)
+
+    keepReadingInto chan src =
+      forever $ do
+        lsReadInto chan src
+          `catches`
+          [ Handler $ \(ex :: DeviceSourceError) -> atomically $ writeTChan chan (Left $ toException ex)
+          , Handler $ \(ex :: IOException) -> atomically $ writeTChan chan (Left $ toException ex)
+          ]
+
+-- | Open multiple device files on a standard linux 64 bit architecture
+deviceSourceMultiple64 :: HasLogFunc e
+  => [FilePath]  -- ^ The filepath to the device file
+  -> RIO e (Acquire KeySource)
+deviceSourceMultiple64 = deviceSourceMultiple defEventParser
+
 
 --------------------------------------------------------------------------------
 -- $io
@@ -128,7 +173,7 @@ deviceSource64 = deviceSource defEventParser
 -- 'IOCtlGrabError' if an ioctl grab could not be properly performed.
 lsOpen :: (HasLogFunc e)
   => KeyEventParser   -- ^ The method by which to decode events
-  -> FilePath      -- ^ The path to the device file
+  -> FilePath         -- ^ The path to the device file
   -> RIO e DeviceFile
 lsOpen pr pt = do
   h  <- liftIO . openFd pt ReadOnly Nothing $


### PR DESCRIPTION
Hacky implementation of multiple inputs on Linux.

My goal was to use extra buttons on my mouse to switch layers on my keyboard, so I needed a way to attach the same kmonad instance to two input devices. Unfortunately, it turns out the mouse pointer stops moving if I run kmonad on the mouse; so I abandonded the idea (I thought the keyboard and mouse parts would be different endpoints, but apparently not). Maybe this code can still be useful for somebody else as a starting point.