### PR TITLE
add aliases for "scroll up/down"

### DIFF
--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -378,6 +378,8 @@ aliases = Q.mkMultiMap
   , (Key102nd,          ["102d", "lsgt", "nubs"])
   , (KeyForward,        ["fwd"])
   , (KeyScrollLock,     ["scrlck", "slck"])
+  , (KeyScrollUp,       ["scrup", "sup"])
+  , (KeyScrollDown,     ["scrdn", "sdwn", "sdn"])
   , (KeyPrint,          ["prnt"])
   , (KeyWakeUp,         ["wkup"])
   , (KeyLeft,           ["lft"])


### PR DESCRIPTION
Added aliases for "Scroll Down" and "Scroll Up".

Feel free to replace them by any better alias, they were just the first I came up with.
But as my keyboard has these two keys, I'd really like to have an alias for them.