### PR TITLE
Vim-like layers: `match-tap-seq` button

### DIFF
--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -385,7 +385,7 @@ joinButton ns als =
     KStickyKey s d     -> jst $ stickyKey (fi s) <$> go d
 
     -- Pattern matching buttons
-    KMatchTapSeq seqs escs db -> jst $ matchTapSeq <$> mapM f seqs <*> mapM f escs <*> mapM g db
+    KMatchTapSeq seqs escs db mods -> jst $ matchTapSeq <$> mapM f seqs <*> mapM f escs <*> mapM g db <*> pure mods
       where f :: (a, (DefButton, b)) -> J (a, (Button, b))
             f (x, db) = (x,) <$> g db
             g :: (DefButton, b) -> J (Button, b)

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -384,6 +384,13 @@ joinButton ns als =
       where f (ms, b) = (fi ms,) <$> go b
     KStickyKey s d     -> jst $ stickyKey (fi s) <$> go d
 
+    -- Pattern matching buttons
+    KMatchTapSeq seqs escs db -> jst $ matchTapSeq <$> mapM f seqs <*> mapM f escs <*> mapM g db
+      where f :: (a, (DefButton, b)) -> J (a, (Button, b))
+            f (x, db) = (x,) <$> g db
+            g :: (DefButton, b) -> J (Button, b)
+            g (d, b) = (,b) <$> go d
+
     -- Non-action buttons
     KTrans -> pure Nothing
     KBlock -> ret pass

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -294,13 +294,17 @@ keywordButtons =
   , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> numP)
   , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)
-  , ("match-tap-seq"  , KMatchTapSeq <$> some ((,) <$> some (lexeme keycodeP) <*> contStopBtn)
-                                     <*> (keywordP "esc" (some ((,) <$> lexeme keycodeP <*> contStopBtn)) <|> pure [])
-                                     <*> optional (keywordP "else" contStopBtn))
+  , ("match-tap-seq"  , KMatchTapSeq <$> some ((,) <$> some (lexeme keycodeWithMods) <*> contStopBtn)
+                                     <*> (keywordP "esc" (some $ (,) <$> lexeme keycodeWithMods <*> contStopBtn) <|> pure [])
+                                     <*> optional (keywordP "else" contStopBtn)
+                                     <*> (keywordP "mod" (some $ (,) <$> some (lexeme keycodeP) <*> lexeme textP) <|> pure []))
   ]
  where
   timed :: Parser [(Int, DefButton)]
   timed = many ((,) <$> lexeme numP <*> lexeme buttonP)
+
+  keycodeWithMods :: Parser ([Text], Keycode)
+  keycodeWithMods = (,) . nub . sort <$> many (lexeme textP) <*> keycodeP
 
   contStopBtn :: Parser (DefButton, Bool)
   contStopBtn = ((, True) <$> keywordP "cont" buttonP) <|> ((,False) <$> keywordP "stop" buttonP)

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -294,10 +294,16 @@ keywordButtons =
   , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> numP)
   , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)
+  , ("match-tap-seq"  , KMatchTapSeq <$> some ((,) <$> some (lexeme keycodeP) <*> contStopBtn)
+                                     <*> (keywordP "esc" (some ((,) <$> lexeme keycodeP <*> contStopBtn)) <|> pure [])
+                                     <*> optional (keywordP "else" contStopBtn))
   ]
  where
   timed :: Parser [(Int, DefButton)]
   timed = many ((,) <$> lexeme numP <*> lexeme buttonP)
+
+  contStopBtn :: Parser (DefButton, Bool)
+  contStopBtn = ((, True) <$> keywordP "cont" buttonP) <|> ((,False) <$> keywordP "stop" buttonP)
 
 -- | Parsers for buttons that do __not__ have a keyword at the start
 noKeywordButtons :: [Parser DefButton]

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -83,7 +83,7 @@ data DefButton
   | KCommand Text (Maybe Text)             -- ^ Execute a shell command on press, as well
                                            --   as possibly on release
   | KStickyKey Int DefButton               -- ^ Act as if a button is pressed for a period of time
-  | KMatchTapSeq [([Keycode], (DefButton, Bool))] [(Keycode, (DefButton, Bool))] (Maybe (DefButton, Bool))
+  | KMatchTapSeq [([([Text], Keycode)], (DefButton, Bool))] [(([Text], Keycode), (DefButton, Bool))] (Maybe (DefButton, Bool)) [([Keycode], Text)]
   | KBeforeAfterNext DefButton DefButton   -- ^ Surround a future button in a before and after tap
   | KTrans                                 -- ^ Transparent button that does nothing
   | KBlock                                 -- ^ Button that catches event

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -83,6 +83,7 @@ data DefButton
   | KCommand Text (Maybe Text)             -- ^ Execute a shell command on press, as well
                                            --   as possibly on release
   | KStickyKey Int DefButton               -- ^ Act as if a button is pressed for a period of time
+  | KMatchTapSeq [([Keycode], (DefButton, Bool))] [(Keycode, (DefButton, Bool))] (Maybe (DefButton, Bool))
   | KBeforeAfterNext DefButton DefButton   -- ^ Surround a future button in a before and after tap
   | KTrans                                 -- ^ Transparent button that does nothing
   | KBlock                                 -- ^ Button that catches event

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -479,8 +479,10 @@ matchTapSeq seqs_ escs elseB modDefs = onPress $ awaitMy Release (pure Catch) >>
     tapIt held (b, cont) = do
       tap b
       my Release >>= inject
-      when cont $
-        go seqs_ held
+      if cont
+        then go seqs_ held
+        else mapM_ (inject . mkKeyEvent Press)
+                   (filter (`elem` allModKeys) held)
 
     go :: [([([Text], Keycode)], (Button, Bool))] -> [Keycode] -> AnyK ()
     go seqs held = hookF InputHook $ \e -> do

--- a/src/KMonad/Prelude/Imports.hs
+++ b/src/KMonad/Prelude/Imports.hs
@@ -8,6 +8,7 @@ import Control.Lens       as X
 import Control.Monad.Cont as X
 import Data.Acquire       as X
 import GHC.Conc           as X (orElse)
+import RIO.List           as X (nub, sort)
 import RIO.Text           as X (unlines, lines, unpack, pack)
 
 import RIO as X hiding


### PR DESCRIPTION
`match-tap-seq` allows 'vim like' layers to be constructed.

The arguments map 'input patterns' to ':cont or :stop buttons'.

There are three kinds of 'input patterns':

- Sequences of keycode presses
- Escape precode presses, valid at any point (see `:esc`)
- An optional fallback for when all sequences failed to match (see `:else`)

A ':cont or :stop button' is configured by entering the `:cont` or `:stop` keyword followed by a button. The button will be tapped when there's a match. Also, depending on what keyword was used, we either continue to match for the next pattern or we exit.

Example configuration:

```
(defalias magic-caps
  (match-tap-seq
    a b c     :cont #(2 3 spc m o r e spc t o spc g o ret)
    a b z     :cont #(n o spc c h e a t i n g ret)
    q u i t   :stop #(b y e spc b y e ret)
    :esc esc  :stop #(b y e ret)
         caps :cont #(r e s t a r t ret)
    :else     :cont #(t r y spc a g a i n ret)
  )
)
```