### PR TITLE
nix: add aarch64-linux to supported systems

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -8,7 +8,7 @@
   outputs = { self, nixpkgs, ... }@inputs:
     let
       # List of supported systems:
-      supportedSystems = [ "x86_64-linux" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
 
       # List of supported compilers:
       supportedCompilers = [


### PR DESCRIPTION
kmonad works flawlessly on my aarch64 laptop running Linux, so I see no reason to mark this platform as unsupported.