### PR TITLE
feat: add tap-next-press

### DIFF
--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -271,6 +271,13 @@ to be the most comfortable.
   (defalias tnr (tap-next-release a sft))
   ```
 
++ `tap-next-press`: like `tap-next` but decide whether to tap or hold
+  based on whether another key is pressed before this one is released.
+
+  ```clojure
+  (defalias tnp (tap-next-press a sft))
+  ```
+
 + `tap-hold-next-release`: like `tap-next-release` but with an
   additional timeout. This is just like `tap-next-release`, but with
   `tap-next` swapped out for `tap-next-release`.

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -760,8 +760,19 @@
     Tesc Ta         -> xa
     Pa Pesc Ra Resc -> ax (because 'a' was already pressed when we started, so
                            foo decides it is tapping)
+    Pesc Pa Resc Ra -> xa (because the first release we encounter is of esc)
     Pesc Ta Resc    -> A (because a was pressed *and* released after we started,
                           so foo decides it is holding)
+
+  `tap-next-press` is also a lot like `tap-next`, but decides whether to tap or
+  hold based on whether another key is pressed before this one is released.
+  Using the minilanguage:
+    (tap-next-press x lsft)
+  Then:
+    Tesc Ta -> xa
+    Pa Pesc Ra Resc -> ax (because esc is released before another key is pressed)
+    Pesc Pa Resc Ra -> A (because a is pressed before esc is released)
+    Pesc Ta Resc    -> A (a is pressed before esc is released here as well)
 
   These increasingly stranger buttons are, I think, coming from the stubborn
   drive of some of my more eccentric (and I mean that in the most positive way)
@@ -785,6 +796,7 @@
   xth (tap-hold 400 x lsft)     ;; Long delay for easier testing
   thn (tap-hold-next 400 x lsft)
   tnr (tap-next-release x lsft)
+  tnp (tap-next-press x lsft)
   tnh (tap-hold-next-release 2000 x lsft)
 
   ;; Used it the colemak layer
@@ -797,7 +809,7 @@
   _    _    _    _    _    _    _    _    _    _    _    _    _    _
   @thn _    _    _    _    _    _    _    _    _    _    _    _
   @xtn _    _    _    _    _    _    _    _    _    _    @xth
-  @tnr _    _              _              _    _    _    @tnh
+  @tnr @tnp _              _              _    _    _    @tnh
 )
 
 

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -376,6 +376,7 @@ joinButton ns als =
     KTapNextRelease t h -> jst $ tapNextRelease    <$> go t <*> go h
     KTapHoldNextRelease ms t h mtb
       -> jst $ tapHoldNextRelease (fi ms) <$> go t <*> go h <*> traverse go mtb
+    KTapNextPress t h  -> jst $ tapNextPress       <$> go t <*> go h
     KAroundNext b      -> jst $ aroundNext         <$> go b
     KAroundNextSingle b -> jst $ aroundNextSingle <$> go b
     KAroundNextTimeout ms b t -> jst $ aroundNextTimeout (fi ms) <$> go b <*> go t

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -275,6 +275,8 @@ keywordButtons =
   , ("tap-hold-next-release"
     , KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP
                           <*> optional (keywordP "timeout-button" buttonP))
+  , ("tap-next-press"
+    , KTapNextPress <$> buttonP <*> buttonP)
   , ("tap-next"       , KTapNext     <$> buttonP     <*> buttonP)
   , ("layer-toggle"   , KLayerToggle <$> lexeme word)
   , ("momentary-layer" , KLayerToggle <$> lexeme word)

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -67,6 +67,7 @@ data DefButton
   | KTapNextRelease DefButton DefButton    -- ^ Do 2 things based on behavior
   | KTapHoldNextRelease Int DefButton DefButton (Maybe DefButton)
     -- ^ Like KTapNextRelease but with a timeout
+  | KTapNextPress DefButton DefButton      -- ^ Like KTapNextRelease but also hold on presses
   | KAroundNext DefButton                  -- ^ Surround a future button
   | KAroundNextSingle DefButton            -- ^ Surround a future button
   | KMultiTap [(Int, DefButton)] DefButton -- ^ Do things depending on tap-count


### PR DESCRIPTION
This addresses the question I posed in https://github.com/kmonad/kmonad/discussions/656.

tap-next-press acts just like tap-next-release, except that it acts as hold on key presses rather than on key releases.

I suppose there could be one or two more functions added to fill out the matrix with `hold` and such, but I'd rather find out whether this has a decent chance of getting merged before I implement those, since I don't personally have a use for them.