### PR TITLE
systemd.unit support for filenames with hyphens

### DIFF
--- a/startup/kmonad@.service
+++ b/startup/kmonad@.service
@@ -4,8 +4,9 @@ Description=kmonad keyboard config
 [Service]
 Restart=always
 RestartSec=3
-ExecStart=/usr/bin/kmonad %E/kmonad/config.kbd
+ExecStart=/usr/bin/kmonad %E/kmonad/%i.kbd
 Nice=-20
 
 [Install]
+DefaultInstance=config
 WantedBy=default.target


### PR DESCRIPTION
When using `/etc/kmonad/*.kbd` files with hyphens in the name systemd
will escape them to slashes when using `%I`. This commit changes to use
`%i` instead which does not escape the name, resulting in the correct
filename passed to kmonad.

It's important to use `%i` for the filename so that multiple instances
of kmonad can run for different keyboards at the same time, say for a
laptop and external keyboard. The `DefaultInstance=config` in line 11
will use a default value of `config` if no other value is given.

Examples:

    `systemctl start kmonad@foo`     # Runs `kmonad /etc/kmonad/foo.kbd`
    `systemctl start kmonad@foo-bar` # Runs `kmonad /etc/kmonad/foo-bar.kbd`
    `systemctl start kmonad@`        # Runs `kmonad /etc/kmonad/config.kbd`
