### PR TITLE
chore: fix `faq.md` broken anchor and mismatched tab/space

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -84,10 +84,10 @@ Create a layout file with an environment variable instead of `device-file` optio
 
 ```
 (defcfg
-	input (device-file "$KBD_DEV")
-	output (uinput-sink "KMonad kbd")
-	fallthrough true
-	cmp-seq lctl
+    input (device-file "$KBD_DEV")
+    output (uinput-sink "KMonad kbd")
+    fallthrough true
+    cmp-seq lctl
 )
 ```
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -77,7 +77,7 @@ X11 lines up well with KMonad. See [this issue](https://github.com/kmonad/kmonad
 A: Unicode entry works via X11 compose-key sequences. For information on how to
 configure kmonad to make use of this, please see [the tutorial](../keymap/tutorial.kbd).
 
-### Q: How do I use the same layout for different keyboards
+### Q: How do I use the same layout definition for different keyboards
 
 A:
 Create a layout file with an environment variable instead of `device-file` option, i.e. `kmonad.kbd`.


### PR DESCRIPTION
- the actual section heading is missing one word from the ToC (and anchor used in ToC)
- the code block is using tab while the rest of the file is using space