### PR TITLE
[Mac] Upgrade Karabiner-DriverKit-VirtualHIDDevice to v2.1.0

### DIFF
--- a/c_src/mac/dext.cpp
+++ b/c_src/mac/dext.cpp
@@ -1,3 +1,5 @@
+#include <filesystem> // Include this before virtual_hid_device_service.hpp to avoid compile error
+
 #include "keyio_mac.hpp"
 
 #include "virtual_hid_device_driver.hpp"
@@ -16,8 +18,7 @@ static pqrs::karabiner::driverkit::virtual_hid_device_driver::hid_report::consum
 
 int init_sink() {
     pqrs::dispatcher::extra::initialize_shared_dispatcher();
-    std::filesystem::path client_socket_file_path("/tmp/karabiner_driverkit_virtual_hid_device_service_client.sock");
-    client = new pqrs::karabiner::driverkit::virtual_hid_device_service::client(client_socket_file_path);
+    client = new pqrs::karabiner::driverkit::virtual_hid_device_service::client();
     auto copy = client;
     client->async_driver_loaded();
     client->async_driver_version_matched();

--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -157,7 +157,7 @@ void monitor_kb(char *product) {
     CFRelease(cfValue);
     io_iterator_t iter = IO_OBJECT_NULL;
     CFRetain(matching_dictionary);
-    kr = IOServiceGetMatchingServices(kIOMasterPortDefault,
+    kr = IOServiceGetMatchingServices(kIOMainPortDefault,
                                       matching_dictionary,
                                       &iter);
     if(kr != KERN_SUCCESS) {
@@ -166,7 +166,7 @@ void monitor_kb(char *product) {
     }
     listener_loop = CFRunLoopGetCurrent();
     open_matching_devices(product, iter);
-    IONotificationPortRef notification_port = IONotificationPortCreate(kIOMasterPortDefault);
+    IONotificationPortRef notification_port = IONotificationPortCreate(kIOMainPortDefault);
     CFRunLoopSourceRef notification_source = IONotificationPortGetRunLoopSource(notification_port);
     CFRunLoopAddSource(listener_loop, notification_source, kCFRunLoopDefaultMode);
     CFRetain(matching_dictionary);

--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -6,6 +6,12 @@
 #include <map>
 #include <iostream>
 #include <mach/mach_error.h>
+#include <AvailabilityMacros.h>
+
+/* The name was changed from "Master" to "Main" in Apple SDK 12.0 (Monterey) */
+#if !defined (MAC_OS_X_VERSION_12_0) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_12_0)
+    #define kIOMainPortDefault kIOMasterPortDefault
+#endif
 
 int init_sink(void);
 int exit_sink(void);

--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -18,7 +18,7 @@ int main() {
     CFDictionarySetValue(matching_dictionary,CFSTR(kIOHIDDeviceUsageKey),cfValue);
     CFRelease(cfValue);
     io_iterator_t iter = IO_OBJECT_NULL;
-    kern_return_t r = IOServiceGetMatchingServices(kIOMasterPortDefault,
+    kern_return_t r = IOServiceGetMatchingServices(kIOMainPortDefault,
                                                    matching_dictionary,
                                                    &iter);
     if(r != KERN_SUCCESS) {


### PR DESCRIPTION
I tried upgrading Karabiner-DriverKit-VirtualHIDDevice to their latest version.

The required work seems surprisingly minimal. I tried compiling and running it on the Ventura and beta version of Sonoma, and it appears to be working fine.

I will update the installation documentation, once we confirm that the new code can be merged.