### PR TITLE
keycodes: Add aliases for `copy` and `pste` for KeyCopy and KeyPaste

### DIFF
--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -382,6 +382,8 @@ aliases = Q.mkMultiMap
   , (KeyScrollLock,     ["scrlck", "slck"])
   , (KeyScrollUp,       ["scrup", "sup"])
   , (KeyScrollDown,     ["scrdn", "sdwn", "sdn"])
+  , (KeyCopy,           ["copy"])
+  , (KeyPaste,          ["pste"])
   , (KeyPrint,          ["prnt"])
   , (KeyWakeUp,         ["wkup"])
   , (KeyLeft,           ["lft"])


### PR DESCRIPTION
These are useful for creating universal copy/paste shortcuts that work
inside and outside of terminals and potentially across operating
systems.

https://github.com/kmonad/kmonad/discussions/461#discussioncomment-7452065
