### PR TITLE
keycodes: alias KeyMenu to menu

### DIFF
--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -395,6 +395,7 @@ aliases = Q.mkMultiMap
   , (KeyComma,          ["comm", ","])
   , (KeyDot,            ["."])
   , (KeySlash,          ["/"])
+  , (KeyMenu,           ["menu"])
   , (KeyNumLock,        ["nlck"])
   , (KeyKpSlash,        ["kp/"])
   , (KeyKpEnter,        ["kprt"])


### PR DESCRIPTION
This keycode opens what's often the "right click context menu" in apps
that support it.

It's useful in workflows like this:

You type something and then an underline appears to indicate it was
misspelled. You can use the arrow keys to go back to the word, then use
the "menu" key to open the menu, select the correct word and press Enter
to accept.

This key is rarely used because it's not conventionally located on
keyboards, but with KMonad, it can be mapped somewhere convenient on a
layer!
