### PR TITLE
[Mac] Upgrade Karabiner-DriverKit-VirtualHIDDevice to v3.1.0

### DIFF
--- a/c_src/mac/dext.cpp
+++ b/c_src/mac/dext.cpp
@@ -20,10 +20,6 @@ int init_sink() {
     pqrs::dispatcher::extra::initialize_shared_dispatcher();
     client = new pqrs::karabiner::driverkit::virtual_hid_device_service::client();
     auto copy = client;
-    client->async_driver_loaded();
-    client->async_driver_version_matched();
-    client->async_virtual_hid_keyboard_ready();
-    client->async_virtual_hid_pointing_ready();
     /**/
     client->connected.connect([copy] {
                                   std::cout << "connected" << std::endl;
@@ -38,19 +34,20 @@ int init_sink() {
     client->error_occurred.connect([](auto&& error_code) {
                                        std::cout << "error_occurred " << error_code << std::endl;
                                    });
-    client->driver_loaded_response.connect([](auto&& driver_loaded) {
+    client->driver_connected.connect([](auto&& driver_connected) {
                                                static std::optional<bool> previous_value;
 
-                                               if (previous_value != driver_loaded) {
-                                                   std::cout << "driver_loaded " << driver_loaded << std::endl;
-                                                   previous_value = driver_loaded;
+                                               if (previous_value != driver_connected) {
+                                                   std::cout << "driver_connected " << driver_connected << std::endl;
+                                                   previous_value = driver_connected;
                                                }
                                            });
-    client->driver_version_matched_response.connect([](auto&& driver_version_matched) {
+    client->driver_version_mismatched.connect([](auto&& driver_version_mismatched) {
                                                         static std::optional<bool> previous_value;
-                                                        if (previous_value != driver_version_matched) {
-                                                            std::cout << "driver_version_matched " << driver_version_matched << std::endl;
-                                                            previous_value = driver_version_matched;
+
+                                                        if (previous_value != driver_version_mismatched) {
+                                                            std::cout << "driver_version_mismatched " << driver_version_mismatched << std::endl;
+                                                            previous_value = driver_version_mismatched;
                                                         }
                                                     });
     /**/

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -175,7 +175,7 @@ Simply run these commands in Windows PowerShell:
 
 kmonad supports macOS 10.12 to 10.15 (Sierra, High Sierra, Mojave, and
 Catalina) and macOS 11.0 (Big Sur). When using driverkit-based extension
-v2.1.0 and later, kmonad also supports macOS 16.0 (Ventura) and 17.0
+v2.1.0 and later, kmonad also supports macOS 13.0 (Ventura) and 14.0
 (Sonoma).
 
 Note: under macOS, `kmonad` uses one of two "system extensions" to

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -174,8 +174,9 @@ Simply run these commands in Windows PowerShell:
 ### macOS
 
 kmonad supports macOS 10.12 to 10.15 (Sierra, High Sierra, Mojave, and
-Catalina) and macOS 11.0 (Big Sur). After the patch which upgraded
-driverkit-based extension to 3.1.0, kmonad also supports macOS 17.0 (Sonoma).
+Catalina) and macOS 11.0 (Big Sur). When using driverkit-based extension
+v2.1.0 and later, kmonad also supports macOS 16.0 (Ventura) and 17.0
+(Sonoma).
 
 Note: under macOS, `kmonad` uses one of two "system extensions" to
 post modified key events to the OS. For macOS Catalina and prior, we
@@ -232,11 +233,10 @@ Therefore, if you use Karabiner-Elements, you may already have the
 dext installed (though maybe a different version number). Run
 `defaults read
 /Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/Info.plist
-CFBundleVersion` to check the version: if `2.1.0` is shown, then the
+CFBundleVersion` to check the version: if `3.1.0` is shown, then the
 installed dext is compatibile with kmonad and you can move onto
 [installing kmonad](#installing-kmonad). If another version is listed,
-this may work too (but has not been tested). For running kmonad on macOS
-17.0 (Sonoma), you should install the dext version 3.1.0.
+this may work too (but has not been tested).
 
 ##### Build and sign the dext yourself
 
@@ -256,7 +256,7 @@ install the extension, and activate the extension.
 
 ```console
   $ cd kmonad/
-  $ open c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/dist/Karabiner-DriverKit-VirtualHIDDevice-2.1.0.pkg
+  $ open c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/dist/Karabiner-DriverKit-VirtualHIDDevice-3.1.0.pkg
 ```
 
 ```console

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -174,7 +174,8 @@ Simply run these commands in Windows PowerShell:
 ### macOS
 
 kmonad supports macOS 10.12 to 10.15 (Sierra, High Sierra, Mojave, and
-Catalina) and macOS 11.0 (Big Sur).
+Catalina) and macOS 11.0 (Big Sur). After the patch which upgraded
+driverkit-based extension to 3.1.0, kmonad also supports macOS 17.0 (Sonoma).
 
 Note: under macOS, `kmonad` uses one of two "system extensions" to
 post modified key events to the OS. For macOS Catalina and prior, we
@@ -234,7 +235,8 @@ dext installed (though maybe a different version number). Run
 CFBundleVersion` to check the version: if `2.1.0` is shown, then the
 installed dext is compatibile with kmonad and you can move onto
 [installing kmonad](#installing-kmonad). If another version is listed,
-this may work too (but has not been tested).
+this may work too (but has not been tested). For running kmonad on macOS
+17.0 (Sonoma), you should install the dext version 3.1.0.
 
 ##### Build and sign the dext yourself
 


### PR DESCRIPTION
Here I upgrade the Karabiner-DriverKit form v2.1.0 to v3.1.0. Some breaking changes were introduced in v3.1.0 so I have to update dext.cpp. According to few responses in #716, this upgrade works well.