### PR TITLE
Mac: ignore keyboards named "Karabiner ..."

### DIFF
--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -75,7 +75,7 @@ void open_matching_devices(char *product, io_iterator_t iter) {
             return;
         }
     }
-    CFStringRef cfkarabiner = CFStringCreateWithCString(kCFAllocatorDefault, "Karabiner VirtualHIDKeyboard", CFStringGetSystemEncoding());
+    CFStringRef cfkarabiner = CFStringCreateWithCString(kCFAllocatorDefault, "Karabiner ", CFStringGetSystemEncoding());
     if(cfkarabiner == NULL) {
         print_iokit_error("CFStringCreateWithCString");
         if(product) {
@@ -89,7 +89,9 @@ void open_matching_devices(char *product, io_iterator_t iter) {
             print_iokit_error("IORegistryEntryCreateCFProperty");
             continue;
         }
-        bool match = (CFStringCompare(cfcurr, cfkarabiner, 0) != kCFCompareEqualTo);
+
+        // any device named "Karabiner ..." should be ignored
+        bool match = !CFStringHasPrefix(cfcurr, cfkarabiner);
         if(product) {
             match = match && (CFStringCompare(cfcurr, cfproduct, 0) == kCFCompareEqualTo);
         }


### PR DESCRIPTION
This PR addresses https://github.com/kmonad/kmonad/issues/753

# Problem

In config, you can optionally specify a keyboard name:

```
input (iokit-name "Apple Internal Keyboard / Trackpad")
input (iokit-name) ;; no name specified
```

If omitted, then KMonad will attach to any keyboards it can find, skipping those that are provided by the Karabiner VirtualHID driver. However -- this filtering is performed by exact string comparison, and the name of the device varies by driver version.

When the VirtualHID device is not filtered out, a loop results; events emitted by KMonad are received by KMonad, processed again, and so on ...

This might look like the following (for a single initial tap on `a`). Note that the `Emitting: Press <a>` is followed by `Received event: Press <a>` (i.e. looped).

```
Received event: Press <a>
Running hooks
Block level set to: 1
Registering untimed hook: 1993
Registering 300ms hook: 1992

--------------------------------------------------------------------------------
Received event: Release <a>
Running hooks
Emitting: Press <a>
Unblocking input stream, no stored events
Emitting: Release <a>

--------------------------------------------------------------------------------
Received event: Press <a>
Running hooks
Block level set to: 1
Registering untimed hook: 1995
Registering 300ms hook: 1994
```

# Fix

Filter out keyboards prefixed "Karabiner " which matches across both older and current (DriverKit-based) versions of the VirtualHIDKeyboard device

## Examples of matched device names

Only the first is filtered by existing code; any / all of the 3 are filtered with this PR.

```
Karabiner VirtualHIDKeyboard
Karabiner DriverKit VirtualHIDKeyboard 1.6.0
Karabiner DriverKit VirtualHIDKeyboard 1.7.0
```
