### PR TITLE
Work around fn key issue

### DIFF
--- a/src/KMonad/Keyboard/IO/Linux/Types.hs
+++ b/src/KMonad/Keyboard/IO/Linux/Types.hs
@@ -106,6 +106,7 @@ sync (MkSystemTime s ns) = LinuxKeyEvent (fi s, fi ns, 0, 0, 0)
 -- | Translate a 'LinuxKeyEvent' to a kmonad 'KeyEvent'
 fromLinuxKeyEvent :: LinuxKeyEvent -> Maybe KeyEvent
 fromLinuxKeyEvent (LinuxKeyEvent (_, _, typ, c, val))
+  | c > 255 = Nothing
   | typ == 1 && val == 0 = Just . mkRelease $ kc
   | typ == 1 && val == 1 = Just . mkPress   $ kc
   | otherwise = Nothing


### PR DESCRIPTION
When pressing the fn key, the application crashes

```
kmonad: toEnum{Keycode}: tag (464) is outside of enumeration's range (0,255)
```

#372 should fix this for real but until then this makes sure the application doesn't crash when pressing the fn key