### PR TITLE
Fix broken kmonad-bin nixos link

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -399,8 +399,8 @@ binary release of kmonad and packages it in the nix-store:
     pkgs = import <nixpkgs> { };
 
     kmonad-bin = pkgs.fetchurl {
-      url = "https://github.com/kmonad/kmonad/releases/download/0.4.2/kmonad-0.4.2-linux";
-      sha256 = "f18334b4d037ca5140f800029222855669748622";
+      url = "https://github.com/kmonad/kmonad/releases/download/0.4.2/kmonad";
+      sha256 = "0j73dzsfnsa7s96gnxhy9v2wz4l8pln0safdlbkz5j4gdasz3lsl";
     };
   in
   pkgs.runCommand "kmonad" {}


### PR DESCRIPTION
I'm not sure if I got the SHA right (`nix-prefetch-url`, right?)