### PR TITLE
fix c_src/mac/list-keyboards.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to get started with the latest, stable binary release, please check 
 Additionally, if you need any help or just want to say hi,
 you can join our [Matrix space](https://matrix.to/#/#Kmonad:matrix.org) or
 jump into our [IRC channel](https://web.libera.chat/#kmonad).
-There is also an unofficial [Discord server](https://discord.gg/3tFfWmnahN).
+There is also an unofficial [Discord server](https://discord.gg/3tFfWmnahN), and a [Kmonad Subreddit](https://www.reddit.com/r/Kmonad/).
 
 ## Features
 

--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -1,6 +1,12 @@
 #include <IOKit/hid/IOHIDLib.h>
 #include <IOKit/hidsystem/IOHIDShared.h>
 
+#if !defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
+#define KIO__PORT_DEFAULT kIOMainPortDefault
+#else
+#define KIO__PORT_DEFAULT kIOMasterPortDefault
+#endif
+
 int main() {
     CFMutableDictionaryRef matching_dictionary = IOServiceMatching(kIOHIDDeviceKey);
     if(!matching_dictionary) {
@@ -18,7 +24,7 @@ int main() {
     CFDictionarySetValue(matching_dictionary,CFSTR(kIOHIDDeviceUsageKey),cfValue);
     CFRelease(cfValue);
     io_iterator_t iter = IO_OBJECT_NULL;
-    kern_return_t r = IOServiceGetMatchingServices(kIOMainPortDefault,
+    kern_return_t r = IOServiceGetMatchingServices(KIO__PORT_DEFAULT,
                                                    matching_dictionary,
                                                    &iter);
     if(r != KERN_SUCCESS) {

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -38,8 +38,7 @@ sudo groupadd uinput
 
 2. Add your user to the `input` and the `uinput` group:
 ``` shell
-sudo usermod -aG input username
-sudo usermod -aG uinput username
+sudo usermod -aG input,uinput username
 ```
 
 Make sure that it's effective by running `groups`. You might have to logout and login.

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -399,8 +399,8 @@ binary release of kmonad and packages it in the nix-store:
     pkgs = import <nixpkgs> { };
 
     kmonad-bin = pkgs.fetchurl {
-      url = "https://github.com/kmonad/kmonad/releases/download/0.4.2/kmonad-0.4.2-linux";
-      sha256 = "f18334b4d037ca5140f800029222855669748622";
+      url = "https://github.com/kmonad/kmonad/releases/download/0.4.2/kmonad";
+      sha256 = "0j73dzsfnsa7s96gnxhy9v2wz4l8pln0safdlbkz5j4gdasz3lsl";
     };
   in
   pkgs.runCommand "kmonad" {}

--- a/src/KMonad/Keyboard/IO/Linux/Types.hs
+++ b/src/KMonad/Keyboard/IO/Linux/Types.hs
@@ -106,6 +106,7 @@ sync (MkSystemTime s ns) = LinuxKeyEvent (fi s, fi ns, 0, 0, 0)
 -- | Translate a 'LinuxKeyEvent' to a kmonad 'KeyEvent'
 fromLinuxKeyEvent :: LinuxKeyEvent -> Maybe KeyEvent
 fromLinuxKeyEvent (LinuxKeyEvent (_, _, typ, c, val))
+  | c > 255 = Nothing
   | typ == 1 && val == 0 = Just . mkRelease $ kc
   | typ == 1 && val == 1 = Just . mkPress   $ kc
   | otherwise = Nothing


### PR DESCRIPTION
Fix failure to compile under MacOS "Mojave" 10.14.6

Version `120000` is probably MacOS "Monterey" 12 - whatever, it works - concept from **webkit**.