### PR TITLE
Added named source blocks

### DIFF
--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -68,7 +68,7 @@ The following are all global config options that one can set in the
 `defcfg` block.
 
 + `fallthrough` (boolean, defaults to `false`): re-emit keys that are
-  not defined in a `defsrc` block.
+  not defined in the corresponding `defsrc` block.
 
   This allows one to only specify certain parts of a layout, with all
   other keys having their "default" meaning.
@@ -317,6 +317,8 @@ just collections of keys.
   `defsrc` is very similar to a layer visually, it is not a one and will
   thus not be used as one! It only serves to define where the different
   keys are and what kind of layout kmonad is initially dealing with.
+  It also supports giving a name via `:name <my-soucre-name>` as the
+  first argument.
 
   For example, an ANSI 60% keyboard may be represented as:
 
@@ -337,6 +339,9 @@ just collections of keys.
 
    For example, defining a qwerty layer, as well as one for special
    symbols and numbers:
+
+   To use a named source block add `:source <my-source-name>` after
+   the layer name.
 
   ```
   (deflayer qwerty

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -61,9 +61,9 @@
 
     KMonad catches input events and tries to match them to various handlers. If
     it cannot match an event to any handler (for example, if it isn't included
-    in the `defsrc` block, or if it is, but the current keymap does not map any
-    buttons to it), then the event gets quietly ignored. If `fallthrough` is set
-    to `true`, any unhandled events simply get reemitted.
+    in the corresponding `defsrc` block, or if it is, but the current keymap
+    does not map any buttons to it), then the event gets quietly ignored. If
+    `fallthrough` is set to `true`, any unhandled events simply get reemitted.
 
   - allow-cmd: `true` or `false`, defaults to `false`
 
@@ -187,7 +187,7 @@
 
 
 #| --------------------------------------------------------------------------
-                         Necessary: the `defsrc` block
+                      Necessary: at least 1 `defsrc` block
 
   It is difficult to explain the `defsrc` block without immediately going into
   `deflayer` blocks as well. Essentially, KMonad maps input-events to various
@@ -208,10 +208,8 @@
   particular case you probably want to set `fallthrough` to `true` in your
   `defcfg` block though.
 
-  In the future we would like to provide support for multiple, named `defsrc`
-  blocks, so that it becomes easier to specify various layers for just the
-  numpad, for example, but at the moment any more or less than 1 `defsrc` block
-  will result in an error.
+  There is also support for named `defsrc` blocks. They contain `:name <my-source>`
+  as the first argument in their definition.
 
   The layouting in the `defsrc` block is completely free, whitespace simply gets
   ignored. We strive to provide a name for every keycode that is no longer than
@@ -238,6 +236,14 @@
   caps a    s    d    f    g    h    j    k    l    ;    '    ret
   lsft z    x    c    v    b    n    m    ,    .    /    rsft
   lctl lmet lalt           spc            ralt rmet cmp  rctl
+)
+
+(defsrc :name numpad
+  nlck kp/ kp* kp-
+  kp7  kp8 kp9 kp+
+  kp4  kp5 kp6
+  kp1  kp2 kp3 kprt
+  kp0    kp.
 )
 
 
@@ -282,6 +288,9 @@
   layer, followed by N 'statements-that-evaluate-to-a-button', where N is
   exactly how many entries are defined in the `defsrc` statement.
 
+  Optionally you can add a `:source <my-source>` parameter after the name to map
+  a layer using a named `defsrc` block.
+
   It is also important to mention that the 'keymap' in KMonad is modelled as a
   stack of layers (just like in QMK). When an event is registered we look in the
   top-most layer for a handler. If we don't find one we try the next layer, and
@@ -323,6 +332,14 @@
   caps a    s    d    f    g    h    j    k    l    ;    '    ret
   lsft z    x    c    v    b    n    m    ,    .    /    rsft
   lctl @num lalt           spc            ralt rmet @sym @tst
+)
+
+(deflayer phone :source numpad
+  nlck kp/ kp* kp-
+  kp1  kp2 kp3 kp+
+  kp4  kp5 kp6
+  kp7  kp8 kp9 kprt
+  kp0    kp.
 )
 
 

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -368,10 +368,17 @@ defaliasP = many $ (,) <$> lexeme word <*> buttonP
 -- $defsrc
 
 defsrcP :: Parser DefSrc
-defsrcP = many $ lexeme keycodeP
-
+defsrcP =
+  DefSrc
+    <$> optional (keywordP "name" word)
+    <*> many (lexeme keycodeP)
 
 --------------------------------------------------------------------------------
 -- $deflayer
+
 deflayerP :: Parser DefLayer
-deflayerP = DefLayer <$> lexeme word <*> many (lexeme buttonP)
+deflayerP =
+  DefLayer
+    <$> lexeme word
+    <*> optional (keywordP "source" word)
+    <*> many (lexeme buttonP)

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -22,7 +22,7 @@ module KMonad.Args.Types
   , DefSettings
   , DefAlias
   , DefLayer(..)
-  , DefSrc
+  , DefSrc(..)
   , KExpr(..)
 
     -- * $defio
@@ -32,6 +32,7 @@ module KMonad.Args.Types
     -- * $lenses
   , AsKExpr(..)
   , AsDefSetting(..)
+  , HasDefSrc(..)
 ) where
 
 
@@ -117,16 +118,23 @@ makeClassy ''CfgToken
 -- A collection of all the different top-level statements possible in a config
 -- file.
 
--- | A list of keycodes describing the ordering of all the other layers
-type DefSrc = [Keycode]
+-- | A list of keycodes describing the ordering used by all other layers
+-- | which is associated with a name.
+data DefSrc = DefSrc
+  { _srcName  :: Maybe Text -- ^ A unique name used to refer to this layer.
+  , _keycodes :: [Keycode]  -- ^ Layer settings containing also the buttons.
+  }
+  deriving Show
+makeClassy ''DefSrc
 
 -- | A mapping from names to button tokens
 type DefAlias = [(Text, DefButton)]
 
 -- | A layer of buttons
 data DefLayer = DefLayer
-  { _layerName :: Text        -- ^ A unique name used to refer to this layer
-  , _buttons   :: [DefButton] -- ^ A list of button tokens
+  { _layerName         :: Text        -- ^ A unique name used to refer to this layer
+  , _associatedSrcName :: Maybe Text  -- ^ The source used by the layer
+  , _buttons           :: [DefButton] -- ^ A list of button tokens
   }
   deriving Show
 


### PR DESCRIPTION
This PR adds named `defsrc` blocks.
To keep backwards compatibility I decided to name them `defsrc'`.

There are some design decisions which could be changed:
1. `defsrc'` instead of something else like `defsrc-named`.
  But I found finding the right name is hard. :|
2. `defsrc'` instead of expanding `defsrc`.
  Expanding `defsrc` through sub expressions
  would be possible since no key could be a sub expression.
  Furthermore it would allow future expansion (e.g.: fallthrough per source)
  ```
  (defsrc (name qwerty)
    q w e r t y
  )
  ```
I opted for `defsrc'` as it was the easiest. Also note that keys not defined in this source are passthrough to other layers (`_`). This was simply the easiest way to implement.
Let me know if you find some issues.
