### PR TITLE
Fix broken compose sequences (including #823)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ### Fixed
 
+- Fixed broken compose sequences (#823)
+
 ## 0.4.2 – 2023-10-07
 
 ### Added

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -176,6 +176,7 @@ test-suite spec
     , hspec
   other-modules:
       KMonad.GestureSpec
+      KMonad.ComposeSeqSpec
   default-language:
       Haskell2010
   build-tool-depends: hspec-discover:hspec-discover == 2.*

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -27,6 +27,7 @@ module KMonad.Args.Parser
   -- * Parsers for Tokens and Buttons
   , otokens
   , itokens
+  , buttonP
   , keywordButtons
   , noKeywordButtons
   )
@@ -240,6 +241,7 @@ composeSeqP = do
 
   -- If matching, parse a button-sequence from the stored text
   case runParser (some buttonP) "" s of
+    -- Parse error never reaches the user. They simply get a message about an unexpected character.
     Left  _ -> fail "Could not parse compose sequence"
     Right b -> pure b
 

--- a/src/KMonad/Keyboard/ComposeSeq.hs
+++ b/src/KMonad/Keyboard/ComposeSeq.hs
@@ -45,7 +45,6 @@ ssComposed = composeSeqs & (each . _1) %~ sanitize
     , ( "spc ("   , '˘'     , "breve" )
     , ( "\" \""   , '¨'     , "diaeresis" )
     , ("spc <"    , 'ˇ'     , "caron")
-    , ("` spc"    , '`'     , "grave")
     , (", spc"    , '¸'     , "cedilla")
     , ("spc spc"  , ' '     , "nobreakspace")
     , ("spc ."    , ' '     , "U2008")
@@ -742,6 +741,7 @@ ssComposed = composeSeqs & (each . _1) %~ sanitize
     , ("> _"      , '≥'     , "U2265")
 
     -- Sequences that should exist but do not work
+    --, ("` spc"    , '`'     , "grave") -- recursive and incorrect. It's <dead_grave> <space> and <dead_grave> is not mapped in en_US
     --, ("^ spc", '^', "asciicircum") -- This overlaps with the normal 'shifted-6' macro for
     -- , ("' j", 'j́', "jacute")
     ]

--- a/src/KMonad/Keyboard/ComposeSeq.hs
+++ b/src/KMonad/Keyboard/ComposeSeq.hs
@@ -20,6 +20,7 @@ module KMonad.Keyboard.ComposeSeq
 where
 
 import KMonad.Prelude
+import RIO.Text.Partial (replace)
 
 --------------------------------------------------------------------------------
 
@@ -30,7 +31,15 @@ import KMonad.Prelude
 -- 3. A descriptive-name
 --
 ssComposed :: [(Text, Char, Text)]
-ssComposed =
+ssComposed = composeSeqs & (each . _1) %~ sanitize
+ where
+  sanitize :: Text -> Text
+  sanitize = replace "(" "\\("
+           . replace ")" "\\)"
+           . replace "_" "\\_"
+
+  composeSeqs :: [(Text, Char, Text)]
+  composeSeqs =
     [ ("' '"      , '´'     , "acute")
     , ( "^ -"     , '¯'     , "macron" )
     , ( "spc ("   , '˘'     , "breve" )

--- a/test/KMonad/ComposeSeqSpec.hs
+++ b/test/KMonad/ComposeSeqSpec.hs
@@ -1,0 +1,22 @@
+module KMonad.ComposeSeqSpec (spec) where
+
+import KMonad.Args.Parser
+import KMonad.Args.Types
+import KMonad.Keyboard.ComposeSeq
+import KMonad.Keyboard.Keycode
+import KMonad.Parsing
+import KMonad.Prelude
+
+import Test.Hspec
+
+spec :: Spec
+spec = describe "compose-sequences" $ traverse_ checkComposeSeq ssComposed
+ where
+  checkComposeSeq (_, c, name) =
+    it ("Compose sequence for " <> unpack name <> " is valid") $
+      runParser buttonP "" (pack [c]) `shouldSatisfy` parsesAsValidComposeSeq
+  parsesAsValidComposeSeq (Right (KComposeSeq seq')) = all isSimple seq'
+  parsesAsValidComposeSeq _ = False
+  isSimple (KEmit _) = True
+  isSimple (KAround b1 b2) = isSimple b1 && isSimple b2
+  isSimple _ = False

--- a/test/KMonad/ComposeSeqSpec.hs
+++ b/test/KMonad/ComposeSeqSpec.hs
@@ -18,5 +18,5 @@ spec = describe "compose-sequences" $ traverse_ checkComposeSeq ssComposed
   parsesAsValidComposeSeq (Right (KComposeSeq seq')) = all isSimple seq'
   parsesAsValidComposeSeq _ = False
   isSimple (KEmit _) = True
-  isSimple (KAround b1 b2) = isSimple b1 && isSimple b2
+  isSimple (KAround (KEmit KeyLeftShift) (KEmit _)) = True
   isSimple _ = False


### PR DESCRIPTION
This fixes the compose sequences broken due to using '(', ')', or '_' which weren't escaped. This also fixes #823. It also add a test to check every compose sequence.
One interesting case is the grave character. It's compose sequence cannot be reached. When looking up the compose sequence in `/usr/share/X11/locale/en_US.UTF-8/Compose` I noticed it being
```xcompose
<dead_grave> <space>			: "`"	grave # GRAVE ACCENT
```
This leads me to believe that most compose sequences using grave have problems.
This leads me to the problem of the keymap kmonad expects.
I thought it was `us` - `basic` but those sequences are for `us` - `intl` (names taken from `/usr/share/X11/xkb/symbols/us`).
This leads me to mark this pull request as a draft. If you have any ideas of what to do with those compose sequences / difference in mapping assumptions, please tell me.