### PR TITLE
Cleanup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For more information on how to install KMonad, please refer to:
 
 For information on how to configure KMonad, please refer you to:
 - [the configuration tutorial](keymap/tutorial.kbd)
+- [quick reference](doc/quick-reference.md)
 - [user configurations](https://github.com/kmonad/kmonad-contrib)
 
 Want to add your own keyboard configuration to [kmonad-contrib]? Just

--- a/changelog.md
+++ b/changelog.md
@@ -8,11 +8,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ### Added
 
+- Added `stepped`. It performs the next button from a circular sequence
+  whenever it is pressed.
+- Implemented named source blocks.
+  To name a source block add `:name <name>` at the beginning of the
+  `defsrc` block. To use it add `:source <name>` after the layer name to the
+  `deflayer` block. (#831)
+
 ### Changed
+
+- Update Karabiner-DriverKit to 3.1.0 (#780)
+- Added tests to check that every button has documentation (#857)
 
 ### Fixed
 
+- Fixed crash on non-US backslash under MacOS (#766)
+- Fixed broken keyboard due to circular event handeling under MacOS (#781)
+- Fixed crash on unhandled buttons by ignoring them (#807)
+- Fixed parse errors relating to whitespace (#796)
 - Fixed broken compose sequences (#823)
+- Fixed parse errors when using keys only available on darwin os (#828)
+- Fixed `around-next` wasn't parsable (#857)
 
 ## 0.4.2 – 2023-10-07
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -167,6 +167,16 @@ The definition of a key chord then looks like this:
   ```clojure
   (defalias ns  (around-next sft))  ;; Shift the next press
   ```
+
++ `around-next-single`: perform only the next event (keypress or release)
+  inside some context.
+
++ `before-after-next`: tap a button prior to key press and tap another
+  after key release.
+  ```clojure
+  (before-after-next tab S-tab a)
+  ```
+
 + `around-next-timeout`: like `around-next` except that if other button press is not detected within
   some timeout, some other button is tapped.
 
@@ -174,14 +184,15 @@ The definition of a key chord then looks like this:
   (around-next-timeout 500 sft XX)
   ```
   
-+ `sticky keys`: act like the key is held temporarily after just one
++ `sticky-key`: act like the key is held temporarily after just one
   press for the given amount of time (in ms).
 
   ```clojure
   (defalias slc (sticky-key 500 lctl))
   ```
   
-+ `stepped button`: perform different buttons in sequence.
++ `stepped`: perform the next button in the circular sequence
+  whenever it is pressed.
   ```clojure
   (stepped (press-only lctl) (release-only lctl))
   ```

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -367,6 +367,25 @@
 
 
 #| --------------------------------------------------------------------------
+                  Optional: press-only / release-only buttons
+
+  - `(press-only x)` : Send the *press* of x when this button is tapped
+  - `(release-only x)` : Send the *release* of x when this button is tapped
+
+  It is possible to define buttons that only press or release a virtual output
+  button. They are useful in tap-macros, especially ones that are going to be
+  executed in a 'known context'. Assume you want to use your physical alt button
+  to *both* open a layer, but also to function as a basic `alt` key. This can be
+  achieved by `(around met (layer-toggle my-layer))`. However, if you have a macro
+  inside `my-layer` that taps alt, then this would release alt until the layer is
+  reactivated (by physically releasing and repressing the `alt` key). The macro,
+  however, can instead be affixed by `(press-only met)`, making the last step of
+  the macro the reactivation of the `alt` key, solving the problem.
+
+  -------------------------------------------------------------------------- |#
+
+
+#| --------------------------------------------------------------------------
                           Optional: modded buttons
 
   Let's start by exploring the various special buttons that are supported by

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -487,6 +487,22 @@
   sl (sticky-key 300 lsft)
   sr (sticky-key 300 rsft))
 
+#| --------------------------------------------------------------------------
+                           Optional: stepped buttons
+
+  Stepped buttons are a bit out there. They allow you to define a button
+  which does something different depending on how often you have pressed it
+  in the past.
+  Why is this useful?
+  Simple, if you want a ctrl-lock which should work like caps-lock but for
+  ctrl you can use `stepped` in combination with `press-only` and create
+  `@ctl-lck` (see below).
+
+  -------------------------------------------------------------------------- |#
+
+(defalias
+  ctl-lck (stepped (press-only lctl) (release-only lctl)))
+
 
 ;; Now we define the 'tst' button as opening and closing a bunch of layers at
 ;; the same time. If you understand why this works, you're starting to grok
@@ -922,15 +938,46 @@
   leader-key that simply times out (by passing a non-button), or a key that can
   still function as a normal key, but also as a leader key when used slowly.
 
+  The variant `around-next-single` does the same thing as `around-next` except
+  it really only concernes the next event (press or release).
+  Consider the button `@ns` (see below) in the following scenario:
+
+    P@ns Pa Tb Ra Tc -> A B c
+
+  If we had used `@ns'` instead, we would get a result we would expect more:
+
+    P@ns' Pa Tb Ra Tc -> A b c
+
+  but we get the following problem instead, since it handles any following
+  event, not just key presses:
+
+    Pa P@ns' Ra Tb -> a b
+
+  Another button which may be seen as a variant is `before-after-next`.
+  It taps a button before and another after the actual button.
+  It can be used to recreate `(around-next a)` via:
+
+    (before-after-next (press-only a) (release-only a))
+
+  but it can also be used in a more productive sense like `@inn`.
+  If you can switch with `tab` and `S-tab` between something,
+  you can use `@inn` to type your next key there:
+
+    T@inn Pctl Ta Rctl
+
+  would commonly select everything in the next container.
+
   I think expansion of this button-style is probably the future of leader-key,
   hydra-style functionality support in KMonad.
 
   -------------------------------------------------------------------------- |#
 
 (defalias
-  ns  (around-next sft)  ;; Shift the next press
-  nnm (around-next @num) ;; Perform next press in numbers layer
+  ns  (around-next sft)        ;; Shift until the release of the next press
+  ns' (around-next-single sft) ;; Shift the next event
+  nnm (around-next @num)       ;; Perform next press in numbers layer
   ntm (around-next-timeout 500 sft XX)
+  inn (before-after-next tab S-tab)
 
 
 )

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -55,6 +55,7 @@ library
       ConstraintKinds
       DeriveFunctor
       DeriveGeneric
+      DeriveDataTypeable
       DeriveTraversable
       FlexibleContexts
       FlexibleInstances
@@ -63,6 +64,7 @@ library
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
+      NamedFieldPuns
       NoImplicitPrelude
       OverloadedStrings
       RankNTypes
@@ -188,6 +190,7 @@ test-suite spec
       ConstraintKinds
       DeriveFunctor
       DeriveGeneric
+      DeriveDataTypeable
       DeriveTraversable
       FlexibleContexts
       FlexibleInstances
@@ -196,6 +199,7 @@ test-suite spec
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
+      NamedFieldPuns
       NoImplicitPrelude
       OverloadedStrings
       RankNTypes

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -18,6 +18,7 @@ description:
 
 extra-source-files:
     changelog.md
+    doc/quick-reference.md
 
 flag kext
     description: build against the kext [macOS only]
@@ -174,7 +175,9 @@ test-suite spec
       base
     , kmonad
     , hspec
+    , rio
   other-modules:
+      KMonad.ButtonDocSpec
       KMonad.GestureSpec
       KMonad.ComposeSeqSpec
   default-language:

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -19,6 +19,7 @@ description:
 extra-source-files:
     changelog.md
     doc/quick-reference.md
+    keymap/tutorial.kbd
 
 flag kext
     description: build against the kext [macOS only]

--- a/src/KMonad/Args.hs
+++ b/src/KMonad/Args.hs
@@ -60,7 +60,7 @@ joinCLI cmd = traverse._KDefCfg %~ insertCliOption cliList
   cliList :: DefSettings
   cliList = catMaybes $
        map flagToMaybe [cmd^.cmdAllow, cmd^.fallThrgh]
-    <> [cmd^.iToken, cmd^.oToken, cmd^.cmpSeq, cmd^.initStr]
+    <> [cmd^.iToken, cmd^.oToken, cmd^.cmpSeq]
 
   -- | Convert command line flags to a 'Maybe' type, where the non-presence, as
   -- well as the default value of a flag will be interpreted as @Nothing@

--- a/src/KMonad/Args/Cmd.hs
+++ b/src/KMonad/Args/Cmd.hs
@@ -44,7 +44,6 @@ data Cmd = Cmd
     -- All 'KDefCfg' options of a 'KExpr'
   , _cmdAllow  :: DefSetting       -- ^ Allow execution of arbitrary shell-commands?
   , _fallThrgh :: DefSetting       -- ^ Re-emit unhandled events?
-  , _initStr   :: Maybe DefSetting -- ^ TODO: What does this do?
   , _cmpSeq    :: Maybe DefSetting -- ^ Key to use for compose-key sequences
   , _oToken    :: Maybe DefSetting -- ^ How to emit the output
   , _iToken    :: Maybe DefSetting -- ^ How to capture the input
@@ -83,7 +82,6 @@ cmdP =
       <*> startDelayP
       <*> cmdAllowP
       <*> fallThrghP
-      <*> initStrP
       <*> cmpSeqP
       <*> oTokenP
       <*> iTokenP
@@ -129,15 +127,6 @@ fallThrghP = SFallThrough <$> switch
   (  long "fallthrough"
   <> short 'f'
   <> help "Whether to simply re-emit unhandled events"
-  )
-
--- | TODO what does this do?
-initStrP :: Parser (Maybe DefSetting)
-initStrP = optional $ SInitStr <$> strOption
-  (  long "init"
-  <> short 't'
-  <> metavar "STRING"
-  <> help "TODO"
   )
 
 -- | Key to use for compose-key sequences

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -197,6 +197,7 @@ joinConfig' = do
 -- | Return a JCfg with all settings from defcfg applied to the env's JCfg
 getOverride :: J JCfg
 getOverride = do
+  -- FIXME: duplicates don't throw errors
   env <- ask
   cfg <- oneBlock "defcfg" _KDefCfg
   let getB = joinButton [] M.empty

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -354,7 +354,6 @@ settingP = let f s p = symbol s *> p in
     [ SIToken      <$> f "input"         itokenP
     , SOToken      <$> f "output"        otokenP
     , SCmpSeq      <$> f "cmp-seq"       buttonP
-    , SInitStr     <$> f "init"          textP
     , SFallThrough <$> f "fallthrough"   bool
     , SAllowCmd    <$> f "allow-cmd"     bool
     , SCmpSeqDelay <$> f "cmp-seq-delay" numP

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -290,6 +290,7 @@ keywordButtons =
   , ("layer-delay"    , KLayerDelay  <$> lexeme numP <*> lexeme word)
   , ("layer-next"     , KLayerNext   <$> lexeme word)
   , ("around-next"    , KAroundNext  <$> buttonP)
+  , ("around-next-single", KAroundNextSingle <$> buttonP)
   , ("before-after-next", KBeforeAfterNext <$> buttonP <*> buttonP)
   , ("around-next-timeout", KAroundNextTimeout <$> lexeme numP <*> buttonP <*> buttonP)
   , ("tap-macro"

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -89,7 +89,9 @@ data DefButton
   | KBeforeAfterNext DefButton DefButton   -- ^ Surround a future button in a before and after tap
   | KTrans                                 -- ^ Transparent button that does nothing
   | KBlock                                 -- ^ Button that catches event
-  deriving Show
+  deriving (Show, Typeable, Data)
+
+instance Plated DefButton
 
 
 --------------------------------------------------------------------------------

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -151,25 +151,24 @@ data IToken
   = KDeviceSource FilePath
   | KLowLevelHookSource
   | KIOKitSource (Maybe Text)
-  deriving Show
+  deriving (Show)
 
 -- | All different output-tokens KMonad can take
 data OToken
   = KUinputSink Text (Maybe Text)
   | KSendEventSink (Maybe (Int, Int))
   | KKextSink
-  deriving Show
+  deriving (Show)
 
 -- | All possible single settings
 data DefSetting
   = SIToken      IToken
   | SOToken      OToken
   | SCmpSeq      DefButton
-  | SInitStr     Text
   | SFallThrough Bool
   | SAllowCmd    Bool
   | SCmpSeqDelay Int
-  deriving Show
+  deriving (Show)
 makeClassyPrisms ''DefSetting
 
 -- | 'Eq' instance for a 'DefSetting'. Because every one of these options may be
@@ -179,7 +178,6 @@ instance Eq DefSetting where
   SIToken{}      == SIToken{}      = True
   SOToken{}      == SOToken{}      = True
   SCmpSeq{}      == SCmpSeq{}      = True
-  SInitStr{}     == SInitStr{}     = True
   SFallThrough{} == SFallThrough{} = True
   SAllowCmd{}    == SAllowCmd{}    = True
   _              == _              = False

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -307,7 +307,7 @@ data Keycode
   | KeyMissionCtrl
   | KeySpotlight
   | KeyDictation
-  deriving (Eq, Show, Bounded, Enum, Ord, Generic, Hashable)
+  deriving (Eq, Show, Bounded, Enum, Ord, Generic, Hashable, Typeable, Data)
 
 
 instance Display Keycode where

--- a/src/KMonad/Util.hs
+++ b/src/KMonad/Util.hs
@@ -43,7 +43,7 @@ import Data.Time.Clock.System
 
 -- | Newtype wrapper around 'Int' to add type safety to our time values
 newtype Milliseconds = Milliseconds { unMS :: Int }
-  deriving (Eq, Ord, Num, Real, Enum, Integral, Show, Read, Generic, Display)
+  deriving (Eq, Ord, Num, Real, Enum, Integral, Show, Read, Generic, Display, Typeable, Data)
 
 -- | Calculate how much time has elapsed between 2 time points
 tDiff :: ()

--- a/test/KMonad/ButtonDocSpec.hs
+++ b/test/KMonad/ButtonDocSpec.hs
@@ -1,0 +1,29 @@
+module KMonad.ButtonDocSpec (spec) where
+
+import KMonad.Args.Parser (keywordButtons)
+import KMonad.Prelude
+
+import RIO.Text (isInfixOf, isPrefixOf)
+
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  (describe "button-docs" . traverse_ checkForDocsIn)
+    [ "doc/quick-reference.md"
+    ]
+ where
+  checkForDocsIn file = do
+    cnt <- runIO $ readFileUtf8 file
+    describe file . sequence_ $ traverse checkForDoc keywordButtons (lines cnt)
+  checkForDoc btn cnt =
+    it ("Doc for " <> unpack (fst btn) <> " exists") $
+      unless (buttonDocExist btn cnt) (expectationFailure "button does not exist in documentation")
+  buttonDocExist = any . checkerFromButton . fst
+  -- ignore deprecated names
+  checkerFromButton "momentary-layer" = const True
+  checkerFromButton "permanent-layer" = const True
+  checkerFromButton btn =
+    isPrefixOf ("- `(" <> btn <> " ")
+      <||> isInfixOf ("`" <> btn <> "`")
+  (<||>) = liftA2 (||)

--- a/test/KMonad/ButtonDocSpec.hs
+++ b/test/KMonad/ButtonDocSpec.hs
@@ -3,7 +3,8 @@ module KMonad.ButtonDocSpec (spec) where
 import KMonad.Args.Parser (keywordButtons)
 import KMonad.Prelude
 
-import RIO.Text (isInfixOf, isPrefixOf)
+import Data.Char (isSpace)
+import qualified RIO.Text as T
 
 import Test.Hspec
 
@@ -11,19 +12,22 @@ spec :: Spec
 spec = do
   (describe "button-docs" . traverse_ checkForDocsIn)
     [ "doc/quick-reference.md"
+    , "keymap/tutorial.kbd"
     ]
  where
   checkForDocsIn file = do
     cnt <- runIO $ readFileUtf8 file
     describe file . sequence_ $ traverse checkForDoc keywordButtons (lines cnt)
   checkForDoc btn cnt =
-    it ("Doc for " <> unpack (fst btn) <> " exists") $
-      unless (buttonDocExist btn cnt) (expectationFailure "button does not exist in documentation")
+    it ("Doc mentions " <> unpack (fst btn)) $
+      unless (buttonDocExist btn cnt) (expectationFailure "button is not mentioned in documentation")
   buttonDocExist = any . checkerFromButton . fst
   -- ignore deprecated names
   checkerFromButton "momentary-layer" = const True
   checkerFromButton "permanent-layer" = const True
   checkerFromButton btn =
-    isPrefixOf ("- `(" <> btn <> " ")
-      <||> isInfixOf ("`" <> btn <> "`")
+    T.isPrefixOf ("- `(" <> btn <> " ") . T.dropWhile isSpace
+      <||> T.isInfixOf ("`" <> btn <> "`")
+      <||> T.isInfixOf ("`" <> btn <> "'")
   (<||>) = liftA2 (||)
+  infixr 2 <||>

--- a/test/KMonad/ButtonDocSpec.hs
+++ b/test/KMonad/ButtonDocSpec.hs
@@ -1,18 +1,25 @@
 module KMonad.ButtonDocSpec (spec) where
 
-import KMonad.Args.Parser (keywordButtons)
+import KMonad.Args.Parser
+import KMonad.Args.Types
 import KMonad.Prelude
 
 import Data.Char (isSpace)
+import Data.Data
 import qualified RIO.Text as T
 
 import Test.Hspec
 
 spec :: Spec
 spec = do
+  docsExistForEveryButtons
+  tutorialMentionsEveryButton
+
+docsExistForEveryButtons :: Spec
+docsExistForEveryButtons =
   (describe "button-docs" . traverse_ checkForDocsIn)
-    [ "doc/quick-reference.md"
-    , "keymap/tutorial.kbd"
+    [ quickReferencePath
+    , tutorialPath
     ]
  where
   checkForDocsIn file = do
@@ -31,3 +38,33 @@ spec = do
       <||> T.isInfixOf ("`" <> btn <> "'")
   (<||>) = liftA2 (||)
   infixr 2 <||>
+
+tutorialMentionsEveryButton :: Spec
+tutorialMentionsEveryButton =
+  describe "button-usage" $
+    sequence_ . traverse checkButtonUsed buttonConstrs =<< runIO getTutorial
+ where
+  checkButtonUsed btn cnt =
+    it ("Buttontype `" <> showConstr btn <> "` appears outside of comments")
+      . unless (containsButton btn cnt)
+      $ expectationFailure ("Buttontype `" <> showConstr btn <> "` is never used")
+  containsButton btn = any . anyButton $ (== btn) . toConstr
+  anyButton f (KDefLayer (DefLayer{_buttons})) = any (anySubButton f) _buttons
+  anyButton f (KDefAlias als) = any (anySubButton f . snd) als
+  anyButton _ _ = False
+  anySubButton f x = f x || anyOf plate f x
+  buttonConstrs = dataTypeConstrs $ dataTypeOf (undefined :: DefButton)
+
+getTutorial :: IO [KExpr]
+getTutorial =
+  either cannotParseTutorial pure . parseTokens
+    =<< readFileUtf8 tutorialPath
+ where
+  cannotParseTutorial err =
+    fail ("Could not parse `" <> tutorialPath <> "`:\n" <> show err)
+      $> []
+
+quickReferencePath :: FilePath
+quickReferencePath = "doc/quick-reference.md"
+tutorialPath :: FilePath
+tutorialPath = "keymap/tutorial.kbd"

--- a/test/KMonad/GestureSpec.hs
+++ b/test/KMonad/GestureSpec.hs
@@ -3,8 +3,6 @@ module KMonad.GestureSpec ( spec ) where
 import KMonad.Prelude
 import KMonad.Gesture
 
-import Data.Either (fromRight)
-
 import Test.Hspec hiding (around)
 
 r :: Either a b -> b


### PR DESCRIPTION
Added missing documentation and added tests to make sure it stays this way.
This also resulted in `around-next-single` being parsable, after it was broken.
I also removed the option `init` which was added in https://github.com/kmonad/kmonad/commit/dcdf5b5b060af1b6311ef48f3d044cad5f0dcf73 and it's documentation from the code was deleted in https://github.com/kmonad/kmonad/commit/031f865d5a22268072ff1a0cf93e2fa9087ec01f
It was used to specify a program to start when kmonad boots up