### PR TITLE
Fix broken compose sequences v2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed broken keyboard due to circular event handeling under MacOS (#781)
 - Fixed crash on unhandled buttons by ignoring them (#807)
 - Fixed parse errors relating to whitespace (#796)
-- Fixed broken compose sequences (#823)
+- Fixed broken compose sequences (#823, #869)
 - Fixed parse errors when using keys only available on darwin os (#828)
 - Fixed `around-next` wasn't parsable (#857)
 

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -89,7 +89,7 @@ data DefButton
   | KBeforeAfterNext DefButton DefButton   -- ^ Surround a future button in a before and after tap
   | KTrans                                 -- ^ Transparent button that does nothing
   | KBlock                                 -- ^ Button that catches event
-  deriving (Show, Typeable, Data)
+  deriving (Show, Eq, Typeable, Data)
 
 instance Plated DefButton
 
@@ -126,7 +126,7 @@ data DefSrc = DefSrc
   { _srcName  :: Maybe Text -- ^ A unique name used to refer to this layer.
   , _keycodes :: [Keycode]  -- ^ Layer settings containing also the buttons.
   }
-  deriving Show
+  deriving (Show, Eq)
 makeClassy ''DefSrc
 
 -- | A mapping from names to button tokens
@@ -138,7 +138,7 @@ data DefLayer = DefLayer
   , _associatedSrcName :: Maybe Text  -- ^ The source used by the layer
   , _buttons           :: [DefButton] -- ^ A list of button tokens
   }
-  deriving Show
+  deriving (Show, Eq)
 
 
 --------------------------------------------------------------------------------
@@ -194,7 +194,7 @@ data KExpr
   | KDefSrc   DefSrc
   | KDefLayer DefLayer
   | KDefAlias DefAlias
-  deriving Show
+  deriving (Show, Eq)
 makeClassyPrisms ''KExpr
 
 

--- a/src/KMonad/Keyboard/ComposeSeq.hs
+++ b/src/KMonad/Keyboard/ComposeSeq.hs
@@ -46,8 +46,6 @@ ssComposed = composeSeqs & (each . _1) %~ sanitize
     , ( "\" \""   , '¨'     , "diaeresis" )
     , ("spc <"    , 'ˇ'     , "caron")
     , (", spc"    , '¸'     , "cedilla")
-    , ("spc spc"  , ' '     , "nobreakspace")
-    , ("spc ."    , ' '     , "U2008")
     , ("o c"      , '©'     , "copyright")
     , ("o r"      , '®'     , "registered")
     , (". >"      , '›'     , "U203a")
@@ -736,7 +734,6 @@ ssComposed = composeSeqs & (each . _1) %~ sanitize
     , ("_ '"      , '⍘'     , "U2358")
     , ("0 ~"      , '⍬'     , "U236c")
     , ("| ~"      , '⍭'     , "U236d")
-    , ("c /"      , '¢'     , "cent" )
     , ("< _"      , '≤'     , "U2264")
     , ("> _"      , '≥'     , "U2265")
 
@@ -744,4 +741,6 @@ ssComposed = composeSeqs & (each . _1) %~ sanitize
     --, ("` spc"    , '`'     , "grave") -- recursive and incorrect. It's <dead_grave> <space> and <dead_grave> is not mapped in en_US
     --, ("^ spc", '^', "asciicircum") -- This overlaps with the normal 'shifted-6' macro for
     -- , ("' j", 'j́', "jacute")
+    --, ("spc spc"  , ' '     , "nobreakspace") -- cannot be parsed since it is matched by `lexeme` of previous token
+    --, ("spc ."    , ' '     , "U2008") -- see above
     ]


### PR DESCRIPTION
This removes the duplicate sequence for `cent` and the non parseable sequences for `nobreakspace` and `U2008`
(except for command line parameters (what the heck?!))
Also adds some test to check for this.

I hope this doesn't morph into a long running series.
The only missing validation at this point is whether it matches the X11 defined compose sequences
but that would require a lot of effort and using them directly instead of comparing whether we copied them correctly
would also be the better solution as it _would_ also solve #79.