### PR TITLE
Fixed typos in comments and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ If you want to get started with the latest, stable binary release, please check 
 Additionally, if you need any help or just want to say hi,
 you can join our [Matrix space](https://matrix.to/#/#Kmonad:matrix.org) or
 jump into our [IRC channel](https://web.libera.chat/#kmonad).
-There is also an unofficial [Discord server](https://discord.gg/3tFfWmnahN), and a [Kmonad Subreddit](https://www.reddit.com/r/Kmonad/).
+There is also an unofficial [Discord server](https://discord.gg/3tFfWmnahN), and a [KMonad Subreddit](https://www.reddit.com/r/Kmonad/).
 
 ## Features
 
 
 KMonad offers advanced customization features such as **layers**, **multi-tap**, **tap-hold**, and much more. These features are usually available at the hardware level on the QMK-firmware enabled keyboards. However, KMonad allows you to enjoy such features in virtually any keyboard by low-level system manipulations.
 
-For a good introduction to KMonad, have a look at [this Youtube video](https://www.youtube.com/watch?v=Dhj1eauljwU).
+For a good introduction to KMonad, have a look at [this YouTube video](https://www.youtube.com/watch?v=Dhj1eauljwU).
 
 
 

--- a/c_src/keyio.c
+++ b/c_src/keyio.c
@@ -12,7 +12,7 @@ int ioctl_keyboard(int fd, int grab) {
   return ioctl(fd, EVIOCGRAB, grab);
 }
 
-// Acquire a filedescriptor as a uinput keyboard
+// Acquire a file descriptor as a uinput keyboard
 int acquire_uinput_keysink(int fd, char *name, int vendor, int product, int version) {
 
   // Designate fd as a keyboard of all keys

--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -216,7 +216,7 @@ void monitor_kb(char *product) {
  * and opens a pipe for this thread to send key event data to the main
  * thread.
  *
- * Loads a the karabiner kernel extension that will send key events
+ * Loads a karabiner kernel extension that will send key events
  * back to the OS.
  */
 extern "C" int grab_kb(char *product) {

--- a/changelog.md
+++ b/changelog.md
@@ -29,11 +29,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### Fixed
 
 - Fixed crash on non-US backslash under MacOS (#766)
-- Fixed broken keyboard due to circular event handeling under MacOS (#781)
+- Fixed broken keyboard due to circular event handling under MacOS (#781)
 - Fixed crash on unhandled buttons by ignoring them (#807)
 - Fixed parse errors relating to whitespace (#796, #875)
 - Fixed broken compose sequences (#823, #869)
-- Fixed parse errors when using keys only available on darwin os (#828)
+- Fixed parse errors when using keys only available on Darwin OS (#828)
 - Fixed `around-next` wasn't parsable (#857)
 
 ## 0.4.2 – 2023-10-07

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -6,9 +6,9 @@
     - [Q: How do I know which event-file corresponds to my keyboard?](#q-how-do-i-know-which-event-file-corresponds-to-my-keyboard)
     - [Q: How do I emit Hyper_L?](#q-how-do-i-emit-hyper_l)
     - [Q: How does Unicode entry work?](#q-how-does-unicode-entry-work)
-    - [Q: How do I use the same layout definition for different keyboards](#q-how-do-i-use-the-same-layout-definition-for-different-keyboards)
+    - [Q: How do I use the same layout definition for different keyboards?](#q-how-do-i-use-the-same-layout-definition-for-different-keyboards)
 - [Windows](#windows)
-    - [How do I start KMonad?](#how-do-i-start-kmonad)
+    - [Q: How do I start KMonad?](#q-how-do-i-start-kmonad)
         - [Using the command-line](#using-the-command-line)
         - [Making a launcher](#making-a-launcher)
 - [Mac](#mac)
@@ -18,6 +18,7 @@
     - [Q: Why can't I remap the Fn key on my laptop?](#q-why-cant-i-remap-the-fn-key-on-my-laptop)
     - [Q: Why do some key combination not work?](#q-why-do-some-key-combination-not-work)
     - [Q: When I run KMonad I get error `Not available under this OS`](#q-when-i-run-kmonad-i-get-error-not-available-under-this-os)
+    - [Q: Where can I find a list of keycodes which can be used in KMonad?](#q-where-can-i-find-a-list-of-keycodes-which-can-be-used-in-kmonad)
 
 <!-- markdown-toc end -->
 
@@ -77,7 +78,7 @@ X11 lines up well with KMonad. See [this issue](https://github.com/kmonad/kmonad
 A: Unicode entry works via X11 compose-key sequences. For information on how to
 configure KMonad to make use of this, please see [the tutorial](../keymap/tutorial.kbd).
 
-### Q: How do I use the same layout definition for different keyboards
+### Q: How do I use the same layout definition for different keyboards?
 
 A:
 Create a layout file with an environment variable instead of `device-file` option, i.e. `kmonad.kbd`.
@@ -107,7 +108,7 @@ kmonad <(echo "$KBDCFG")
 
 ## Windows
 
-### How do I start KMonad?
+### Q: How do I start KMonad?
 
 A: This might be confusing if you are used to using a GUI and clicking on
 things. Double clicking KMonad will look like it does nothing. KMonad is a

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -75,7 +75,7 @@ X11 lines up well with KMonad. See [this issue](https://github.com/kmonad/kmonad
 ### Q: How does Unicode entry work?
 
 A: Unicode entry works via X11 compose-key sequences. For information on how to
-configure kmonad to make use of this, please see [the tutorial](../keymap/tutorial.kbd).
+configure KMonad to make use of this, please see [the tutorial](../keymap/tutorial.kbd).
 
 ### Q: How do I use the same layout definition for different keyboards
 
@@ -187,9 +187,9 @@ corresponding to F1; macOS then translates this keycode to a special feature
 driver](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice/issues/1). But
 `kmonad` intercepts key presses before this translation can occur, and it emits
 keypresses through a driver of its own. Therefore macOS does not translate any
-keypresses emitted by kmonad, and the checkbox labeled "Use F1, F2, etc. keys as
+keypresses emitted by KMonad, and the checkbox labeled "Use F1, F2, etc. keys as
 standard function keys" in `System Preferences` will have no effect on keyboards
-modified by kmonad.
+modified by KMonad.
 
 However, we can simulate the default behavior of Apple keyboards by emitting
 keycodes that correspond to the special features printed on the function
@@ -200,7 +200,7 @@ example.
 
 ### Q: Why doesn't the 'Print' keycode work for my print screen button?
 
-A: Because the Keycode for "print screen" is actually 'SysReq' ("ssrq" or "sys")
+A: Because the keycode for "print screen" is actually 'SysReq' ("ssrq" or "sys")
 for relatively interesting historical reasons. Have a look at [this
 issue](https://github.com/kmonad/kmonad/issues/59) if you want more
 information.

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -30,7 +30,7 @@
 ## Compilation
 
 Note that, regardless of which compilation method you choose, `git`
-needs to be in `$PATH` when compiling kmonad.  This is because we insert
+needs to be in `$PATH` when compiling KMonad.  This is because we insert
 the current commit into the output of `--version` at compile time.
 
 ### Using `stack`
@@ -65,7 +65,7 @@ the karabiner submodule:
 nix build "./nix?submodules=1"
 ```
 
-If you want to pull in kmonad as a flake input for configuring a darwin system,
+If you want to pull in KMonad as a flake input for configuring a Darwin system,
 you may find it necessary to use a reference like:
 `git+https://github.com/kmonad/kmonad?submodules=1&dir=nix` instead of
 `github:...`.
@@ -119,7 +119,7 @@ docker rmi kmonad-builder
 You will find a `kmonad` binary in your current directory.
 
 As an added bonus, with recent Docker versions you can build images straight
-from public repo URLs, whithout even needing to clone the repo.
+from public repo URLs, without even needing to clone the repo.
 Do this as the build step (the first one) in the previous instructions:
 ``` shell
 docker build -t kmonad-builder github.com/kmonad/kmonad.git
@@ -136,10 +136,10 @@ podman run --rm -it -v ${PWD}:/host/ --security-opt label=disable kmonad-builder
 ### Windows environment
 
 I have little experience with Haskell under windows, but I managed to compile
-`kmonad` under Windows10 using a [Haskell platform
+`kmonad` under Windows 10 using a [Haskell platform
 installation](https://www.haskell.org/platform). I also needed to install
 [mingw](http://mingw.org) to provide `gcc`. With both the Haskell platform and
-`mingw` building `kmonad` under Windows10 should as simple as `stack build`.
+`mingw` building `kmonad` under Windows 10 should be as simple as `stack build`.
 
 You also can install MSYS2, Haskell and stack via [scoop](https://scoop.sh/).
 Simply run these commands in Windows PowerShell:
@@ -173,16 +173,16 @@ Simply run these commands in Windows PowerShell:
 
 ### macOS
 
-kmonad supports macOS 10.12 to 10.15 (Sierra, High Sierra, Mojave, and
+KMonad supports macOS 10.12 to 10.15 (Sierra, High Sierra, Mojave, and
 Catalina) and macOS 11.0 (Big Sur). When using driverkit-based extension
-v2.1.0 and later, kmonad also supports macOS 13.0 (Ventura) and 14.0
+v2.1.0 and later, KMonad also supports macOS 13.0 (Ventura) and 14.0
 (Sonoma).
 
-Note: under macOS, `kmonad` uses one of two "system extensions" to
+Note: Under macOS, `kmonad` uses one of two "system extensions" to
 post modified key events to the OS. For macOS Catalina and prior, we
 use a [kernel
 extension](https://github.com/pqrs-org/Karabiner-VirtualHIDDevice)
-(kext), which is bundled with kmonad as a submodule in
+(kext), which is bundled with KMonad as a submodule in
 `c_src/mac/Karabiner-VirtualHIDDevice`. For macOS Catalina and later,
 we use a [driverkit-based
 extension](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice)
@@ -234,7 +234,7 @@ dext installed (though maybe a different version number). Run
 `defaults read
 /Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/Info.plist
 CFBundleVersion` to check the version: if `3.1.0` is shown, then the
-installed dext is compatibile with kmonad and you can move onto
+installed dext is compatible with kmonad and you can move onto
 [installing kmonad](#installing-kmonad). If another version is listed,
 this may work too (but has not been tested).
 

--- a/doc/module_structure.md
+++ b/doc/module_structure.md
@@ -28,7 +28,7 @@ These all belong in App:
 - keyboard specific data declarations and operations
 - invocation parsing
 - configuration parsing
-- the entrypoint of KMonad
+- the entry point of KMonad
 
 Essentially, in App we have the `main` function. It then starts doing a variety
 of IO tasks to set up an environment in which to run our model. This environment
@@ -97,9 +97,9 @@ This module contains the following submodules:
 Note, however, that configurations should parse *on any OS*. This means that the
 configuration records for, for example, key-IO, should be defined on all
 platforms. To that extent, the `Common` module itself contains 3 submodules:
-- `Linux`: for code pertaining to Linux, but runable everywhere
-- `Mac`: for code pertaining to Mac, but runable everywhere
-- `Windows`: for code pertaining to Windows, but runable everywhere
+- `Linux`: for code pertaining to Linux, but runnable everywhere
+- `Mac`: for code pertaining to Mac, but runnable everywhere
+- `Windows`: for code pertaining to Windows, but runnable everywhere
 
 This might seem circumspect, and it does mean that the configuration-record is
 specified in a different module than the runtime-environment for various key-IO

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -35,8 +35,8 @@ A block can take the following arguments:
 
 + `input`: define the input keyboard which the program will capture.
 
-+ `output`: define the output keyboard which kmonad will create, with
-  additional options to execute upon starting kmonad.
++ `output`: define the output keyboard which KMonad will create, with
+  additional options to execute upon starting KMonad.
 
 Here is how you would define the basic input and output settings on all
 supported systems:
@@ -132,7 +132,7 @@ the macro the reactivation of the `alt` key, solving the problem.
 
 ## Modded Buttons
 
-To make key-entry easier, kmonad already provides some syntax for
+To make key-entry easier, KMonad already provides some syntax for
 Emacs-like specification of key chords. They are defined like this:
 
   - `C-` : `(around-implicit lctl X)`
@@ -267,7 +267,7 @@ The definition of a key chord then looks like this:
 
 ## Tap buttons
 
-Tap buttons are an integral part of kmonad. Everyone has different
+Tap buttons are an integral part of KMonad. Everyone has different
 preferences—that's why there are so many! Particularly when using
 home-row modifiers, you will find some of the more crazy seeming buttons
 to be the most comfortable.

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -109,7 +109,7 @@
     setting this value to `5' or `10' and see if that helps.
 
   Secondly, let's go over how to specify the `input` and `output` fields of a
-  `defcfg` block. This differs between OS'es, and so do the capabilities of
+  `defcfg` block. This differs between OSes, and so do the capabilities of
   these interfaces.
 
 
@@ -450,7 +450,7 @@
   `around-implicit` is one of the above variants and is specified `defcfg` block.
 
   We have already seen other examples of modded buttons, \(, \), *, and +. There
-  are no Keycodes for these buttons in KMonad, but they are buttons. They simply
+  are no keycodes for these buttons in KMonad, but they are buttons. They simply
   evaluate to `(around-implicit lsft x)`. All shifted numbers have their
   corresponding characters, the same is true for all capitals,
   and < > : ~ " | { } \_ + and ?.
@@ -574,7 +574,7 @@
 
   `tap-macro` is a function that takes an arbitrary number of buttons and
   returns a new button. When this new button is pressed it rapidly taps all its
-  stored buttons in quick succesion except for its last button, which it only
+  stored buttons in quick succession except for its last button, which it only
   presses. This last button gets released when the `tap-macro` gets released.
 
   There are two ways to define a `tap-macro`, using the `tap-macro` function
@@ -692,10 +692,10 @@
     (layer-switch my-layer)
 
   This is where things start getting potentially dangerous (i.e. get KMonad into
-  an unusuable state until a restart has occured). It is perfectly possible to
+  an unusable state until a restart has occurred). It is perfectly possible to
   switch into a layer that you can never get out of. Or worse, you could
   theoretically have a layer full of only `XX`s and switch into that, rendering
-  your keyboard unuseable until you somehow manage to kill KMonad (without using
+  your keyboard unusable until you somehow manage to kill KMonad (without using
   your keyboard).
 
   However, when handled well, `layer-switch` is very useful, letting you switch
@@ -941,7 +941,7 @@
 #| --------------------------------------------------------------------------
                               Optional: Multi-tap
 
-  Besides the tap-hold style buttons there is another multi-use button (with.
+  Besides the tap-hold style buttons there is another multi-use button (with
   only 1 variant, at the moment). The `multi-tap`.
 
   A `multi-tap` codes for different buttons depending on how often it is tapped.
@@ -976,7 +976,7 @@
   still function as a normal key, but also as a leader key when used slowly.
 
   The variant `around-next-single` does the same thing as `around-next` except
-  it really only concernes the next event (press or release).
+  it really only concerns the next event (press or release).
   Consider the button `@ns` (see below) in the following scenario:
 
     P@ns Pa Tb Ra Tc -> A B c
@@ -1038,7 +1038,7 @@
   To get this to work on Linux you will need to set your compose-key with a tool
   like `setxkbmap', as well as tell KMonad that information. See the `defcfg'
   block at the top of this file for a working example. Note that you need to
-  wait ever so slightly for the keyboard to register with linux before the
+  wait ever so slightly for the keyboard to register with Linux before the
   command gets executed, that's why the `sleep 1`. Also, note that all the
   `/run/current-system' stuff is because the author uses NixOS. Just find a
   shell-command that will:

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -70,7 +70,7 @@
         ];
         statSubmodulePhase = ''
           stat c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include || (
-            echo "Karabiner submodule not found. This flake needs to be built with submodules on darwin. See the kmonad docs for more information." 1>&2
+            echo "Karabiner submodule not found. This flake needs to be built with submodules on darwin. See the KMonad docs for more information." 1>&2
             exit 1
           )
         '';

--- a/src/KMonad/App/Main.hs
+++ b/src/KMonad/App/Main.hs
@@ -80,7 +80,7 @@ initAppEnv cfg = do
   -- Wait a bit for the user to release the 'Return' key with which they started KMonad
   threadDelay $ fromIntegral (cfg^.startDelay) * 1000
 
-  -- Acquire the keysource and keysink
+  -- Acquire the key source and key sink
   snk <- using $ cfg^.keySinkDev
   src <- using $ cfg^.keySourceDev
 

--- a/src/KMonad/App/Types.hs
+++ b/src/KMonad/App/Types.hs
@@ -144,6 +144,6 @@ instance (HasAppEnv e, HasAppCfg e, HasLogFunc e) => MonadKIO (RIO e) where
     spawnCommand cmd = void $ createProcess_ "spawnCommand"
       (shell cmd){ -- We don't want the child process to inherit things like
                    -- our keyboard grab (this would, for example, make it
-                   -- impossible for a command to restart kmonad).
+                   -- impossible for a command to restart KMonad).
                    close_fds   = True
                  }

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -110,7 +110,7 @@ data ImplArnd
 --------------------------------------------------------------------------------
 -- $cfg
 --
--- The Cfg token that can be extracted from a config-text without ever enterring
+-- The Cfg token that can be extracted from a config-text without ever entering
 -- IO. This will then directly be translated to a DaemonCfg
 --
 

--- a/src/KMonad/Keyboard/IO/Linux/Types.hs
+++ b/src/KMonad/Keyboard/IO/Linux/Types.hs
@@ -103,7 +103,7 @@ sync (MkSystemTime s ns) = LinuxKeyEvent (fi s, fi ns, 0, 0, 0)
 --           see: https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
 --         for sync: always 0
 
--- | Translate a 'LinuxKeyEvent' to a kmonad 'KeyEvent'
+-- | Translate a 'LinuxKeyEvent' to a KMonad 'KeyEvent'
 fromLinuxKeyEvent :: LinuxKeyEvent -> Maybe KeyEvent
 fromLinuxKeyEvent (LinuxKeyEvent (_, _, typ, c, val))
   | c > 255 = Nothing
@@ -113,7 +113,7 @@ fromLinuxKeyEvent (LinuxKeyEvent (_, _, typ, c, val))
   where
     kc = toEnum . fromIntegral $ c -- This is theoretically partial, but practically not
 
--- | Translate kmonad 'KeyEvent' along with a 'SystemTime' to 'LinuxKeyEvent's
+-- | Translate KMonad 'KeyEvent' along with a 'SystemTime' to 'LinuxKeyEvent's
 -- for writing.
 toLinuxKeyEvent :: KeyEvent -> SystemTime -> LinuxKeyEvent
 toLinuxKeyEvent e (MkSystemTime s ns)

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -37,7 +37,7 @@ import qualified RIO.Text.Partial  as T (head)
 -- headers:
 -- https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h.
 --
--- Anywhere there are missing regions in the linux headers, we've defined
+-- Anywhere there are missing regions in the Linux headers, we've defined
 -- @MissingXX@ values for the ADT.
 --
 -- Calling 'RIO.Partial.toEnum' on a Linux keycode value should produce the

--- a/src/KMonad/Model/Dispatch.hs
+++ b/src/KMonad/Model/Dispatch.hs
@@ -26,7 +26,7 @@ ever get lost.
 
 In the sequencing of components, the 'Dispatch' occurs first, which means that
 it reads directly from the KeySource. Any component after the 'Dispatch' need
-not worry about wether an event is being rerun or not, it simply treats all
+not worry about whether an event is being rerun or not, it simply treats all
 events as equal.
 
 -}

--- a/src/KMonad/Util/LayerStack.hs
+++ b/src/KMonad/Util/LayerStack.hs
@@ -102,7 +102,7 @@ mkLayerStack :: (Foldable t1, Foldable t2, CanKey k, CanKey l)
   => t1 (l, t2 (k, a)) -- ^ The /alist/ of /alists/ describing the mapping
   -> LayerStack l k a
 mkLayerStack nestMaps = let
-  -- Create a HashMap l (Layer k a) from the listlikes
+  -- Create a HashMap l (Layer k a) from the list-likes
   hms = M.fromList . map (over _2 mkLayer) $ toList nestMaps
 --   -- Create a HashMap (l, k) a from `hms`
   its = M.fromList $ hms ^@.. ifolded <.> (to unLayer . ifolded)

--- a/startup/kmonad@.service
+++ b/startup/kmonad@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=kmonad keyboard config
+Description=KMonad keyboard config
 
 [Service]
 Restart=always


### PR DESCRIPTION
Some instances of "kmonad" have been left unchanged (capitalization) since they (probably) refer to the executable.