### PR TITLE
Fix tapping in inner

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed broken compose sequences (#823)
 - Fixed parse errors when using keys only available on darwin os (#828)
 - Fixed `around-next` wasn't parsable (#857)
+- Fixed most buttons which behave weird in nested tap situations (#873)
 
 ## 0.4.2 – 2023-10-07
 


### PR DESCRIPTION
This fixes the problems described in #872 for the following buttons:
- [X] `around-only`
- [x] `around-when-alone`
- [ ] `around-next`
- [ ] `around-next-timeout`
- [ ] `around-next-single`
- [X] `tap-on` (does not exists but has code?!)\*
- [X] `tap-hold`
- [X] `tap-next`
- [X] `tap-hold-next`
- [ ] `before-after-next`
- [X] `tap-next-release`
- [X] `tap-hold-next-release`
- [X] `tap-next-press`
- [X] `multi-tap`
- [X] `tap-macro`
- [X] `tap-macro-release`
- [ ] `layer-next`
- [ ] `sticky-key`
- [ ] `retap` (Not yet implemented. See #882)
- [ ] `stepped-button`

\* `tap-on` is just made more readable. It wasn't broken.

The other unfixed buttons require a deeper rewrite to function on the next button instead of on the next key press (if that is what we want? Probably.).

This also allows us to rerevert 2d11c6306ebd209796474da83efeefd607a30e6c but #859 maybe has other problems with something like `S-(layer-toggle <...>)` which I have seen in old issues. Though there was always another mention of a solution which works better which didn't use that or `(around lsft (layer-toggle <...>))`.