### PR TITLE
Update compiler and build setup in the dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,24 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
-        with:
-          path: image.tar
-          key: ${{ runner.os }}-primes
-
-      - run: |
-          [ -r image.tar ] && docker load -i image.tar || true
-          rm image.tar || true
-
-      - run: docker build . -t kmonad-builder --cache-from=kmonad-builder:latest
+      - run: docker build . -t kmonad-builder
 
       - run: docker run --rm -v ${PWD}:/host/ kmonad-builder bash -c 'cp -vp /root/.local/bin/kmonad /host/'
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: kmonad-binary
           path: kmonad
-
-      - run: docker save kmonad-builder -o image.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM lierdakil/alpine-haskell:8.10.7
+FROM lierdakil/alpine-haskell:9.4.8
 
 WORKDIR /usr/src/kmonad/
 RUN apk --no-cache add git
 RUN stack update
 
-COPY ./kmonad.cabal ./
-COPY ./static/stack.yaml ./static/
-COPY ./stack.yaml ./
-RUN cat ./static/stack.yaml >> stack.yaml && \
-  stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies
+COPY ./kmonad.cabal ./stack.yaml ./
+RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies --ghc-options="-fPIC"
 COPY ./ ./
-RUN cat ./static/stack.yaml >> stack.yaml && \
-  stack --no-install-ghc --system-ghc --skip-ghc-check install --ghc-options -j
+RUN sed -i '/executable kmonad/ a\  ld-options: -static' kmonad.cabal && \
+  stack --no-install-ghc --system-ghc --skip-ghc-check install --ghc-options="-j -fPIC"

--- a/static/stack.yaml
+++ b/static/stack.yaml
@@ -1,2 +1,0 @@
-ghc-options:
-  $everything: -optl-pthread -optl-static -fPIC -fasm -split-sections


### PR DESCRIPTION
This PR updates the GHC version used in the dockerfile for static builds (which is also used in CI). Also tweaks the CI job, specifically updates actions to latest versions and removes caching for the docker build.

The caching thing is curious. For one, it makes the jobs failure-prone due to "no space left on the device" thing (if you've worked with github actions and docker for some time, you've seen it). Besides, docker image caches don't work like they used to, now that buildx is the default, and the build only takes about 6 minutes from scratch. It's just not worth the trouble at this point.

The old setup for static builds no longer works, but there's now a simpler approach which only requires `-fPIC` and adding `ld-options: -static` to the cabalfile, which the dockerfile patches in-place.

To be honest, I'm fascinated this still works, 8.10 is quite outdated. To be fair, 9.4 is also somewhat outdated, but the root stack.yaml uses lts-21, which is on 9.4, so I've opted to use that for consistency.

P.S. the CI job is run on push and not on PR (by design), so you can't see it succeeding here. But it works as intended on my fork: https://github.com/lierdakil/kmonad/actions/runs/10652049346