### PR TITLE
Implement retap button

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
   If you previously used the buttons `missing247` and `missing248`, please update to the new names.
 - Added more MacOS keys (#936)
 - Added keycodes above 255. If you are on linux you can use them now. (#935)
+- Added `retap` which presses another button if the corresponding button is
+  repressed within a certain time period (#882)
 
 ### Changed
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -303,6 +303,14 @@ to be the most comfortable.
   (defalias mt  (multi-tap 300 a 300 b 300 c 300 d e))
   ```
 
++ `retap`: press another button if this one is repressed within a
+  certain time period
+  ```clojure
+  (defalias ssft (retap 200 sft (sticky-key 1000 sft)))
+  ```
+  `ssft` is like shift. When repressed within 200ms it acts as
+  a sticky-key (see `sticky-key`).
+
 + `tap-next`: combine 2 buttons, one for when the button is tapped and
   one for when it is held. The decision of what to execute is based upon
   whether the next button is the buttons own release or not.

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -542,6 +542,17 @@
 (defalias
   ctl-lck (stepped (press-only lctl) (release-only lctl)))
 
+#| --------------------------------------------------------------------------
+                            Optional: retap buttons
+
+  `retap` is used to add a special behaviour when the corresponding button is
+  repressed within a certain timeout after it has been released.
+  You can use this to make a modifier sticky (see below)
+
+  -------------------------------------------------------------------------- |#
+
+(defalias
+  ssft (retap 200 sft (sticky-key 1000 sft)))
 
 ;; Now we define the 'tst' button as opening and closing a bunch of layers at
 ;; the same time. If you understand why this works, you're starting to grok

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -412,6 +412,7 @@ joinButton ns als =
     KPause ms          -> jst . pure $ onPress (pause ms)
     KMultiTap bs d     -> jst $ multiTap <$> go d <*> mapM f bs
       where f (ms, b) = (fi ms,) <$> go b
+    KRetap ms t rt     -> jst $ retap (fi ms) <$> go t <*> go rt
     KStepped bs        -> jst $ steppedButton <$> mapM go bs
     KStickyKey s d     -> jst $ stickyKey (fi s) <$> go d
 

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -301,6 +301,7 @@ keywordButtons =
   , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
   , ("pause"          , KPause . fromIntegral <$> lexeme numP)
   , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)
+  , ("retap"          , KRetap       <$> lexeme numP <*> buttonP <*> buttonP)
   ]
   ++ map (\(nm,_,btn) -> (nm, btn <$> buttonP <*> buttonP)) implArndButtons
  where

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -92,6 +92,8 @@ data DefButton
   | KCommand Text (Maybe Text)             -- ^ Execute a shell command on press, as well
                                            --   as possibly on release
   | KStickyKey Int DefButton               -- ^ Act as if a button is pressed for a period of time
+  | KRetap Int DefButton DefButton
+    -- ^ Press another button if this one is repressed within a certain time period
   | KBeforeAfterNext DefButton DefButton   -- ^ Surround a future button in a before and after tap
   | KTrans                                 -- ^ Transparent button that does nothing
   | KBlock                                 -- ^ Button that catches event

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -58,6 +58,7 @@ module KMonad.Model.Button
   , tapMacro
   , tapMacroRelease
   , steppedButton
+  , retap
   , stickyKey
   )
 where
@@ -583,6 +584,13 @@ stickyKey ms b = onPress go
                *> inject (t^.event)
                *> after 3 (runAction $ b^.releaseAction)
                $> Catch)
+
+-- | Press another button if this one is repressed within a certain time period
+retap :: Milliseconds -> Button -> Button -> Button
+retap ms t rt =
+  mkButton (runAction $ t^.pressAction) $ do
+    runAction $ t^.releaseAction
+    within ms (matchMy Press) (pure ()) . const $ press rt $> Catch
 
 -- | Create a button that functions as a different button everything it is pushed
 --


### PR DESCRIPTION
`retap` is a button which allows you to specify another action, which gets executed when this button is retapped.
Personally this is not that useful to me yet since #256 / #524 is not yet fixed / merged ~~and I want to use something like `(tap-hold-next-release 200 a (retap 200  sft (sticky-key 1000  sft)))`.~~\*
I also don't want it to delay #879.
EDIT:
\* Using this with home row buttons was wierd since typing `Button` on dvorak caused `Btton` (`BTton` with #256 fixed) every time. (`u` was my `sft` home mod).

In most other cases something like `multi-tap` is probably preferred.
Since their is currently no use case or request I will convert it to a draft. If anyone still wants it please provide a use case to consider (I don't want to bloat KMonad when not necessary)