### PR TITLE
Added names for `rfkill` and `micmute`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ### Added
 
+- Added names for the keys `rfkill` and `micmute` (#883).
+  If you previously used the buttons `missing247` and `missing248`, please update to the new names.
+
 ### Changed
 
 ### Fixed

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -292,8 +292,8 @@ data Keycode
   | KeyBrightnessZero
   | KeyDisplayOff
   | KeyWimax
-  | Missing247
-  | Missing248
+  | KeyRfkill
+  | KeyMicmute
   | Missing249
   | Missing250
   | Missing251
@@ -407,6 +407,7 @@ aliases = Q.mkMultiMap
   , (KeyNextSong,         ["next"])
   , (KeyPlayPause,        ["pp"])
   , (KeyPreviousSong,     ["prev"])
+  , (KeyMicmute,          ["micm"])
   -- Darwin
   , (KeyLaunchpad,        ["lp"])
   , (KeyMissionCtrl,      ["mctl"])


### PR DESCRIPTION
Taken from https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h

This leads to a potential new problem:
We already supported the keys, they were just `missing247` and `missing248`
if you did use them in your config you wouldn't get a warning like: "Key has a name", but instead get an error about an unknown key.