### PR TITLE
Fixed / changed `tap-next` and `tap-hold-next`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### Changed
 
 - `multi-tap` now holds when interrupted by another key while held. (#897)
+- Modified `tap-next` and `tap-hold-next` to decide without considering
+  button releases (#884)
 
 ### Fixed
 

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -801,9 +801,9 @@
 
   The `tap-next` button takes 2 buttons, one for tapping, one for holding, and
   combines them into a single button. When pressed, if the next event is its own
-  release, we tap the 'tapping' button. In all other cases we first press the
-  'holding' button then we handle the event. Then when the `tap-next` gets
-  released, we release the 'holding' button.
+  release, we tap the 'tapping' button. If another button is pressed after this one
+  we first press the 'holding' button then we handle the event.
+  Then when the `tap-next` gets released, we release the 'holding' button.
 
   So, using our mini-language, we set foo to:
     (tap-next x lsft)


### PR DESCRIPTION
Fixes #572
Changelog entry is under changed since tutorial specified the old behaviour while quick-reference, comments and the maintainer (in #572) specified it as a bug.