### PR TITLE
Fixed MacOS build

### DIFF
--- a/c_src/mac/kext.cpp
+++ b/c_src/mac/kext.cpp
@@ -41,7 +41,7 @@ int exit_sink() {
 int init_sink() {
     kern_return_t kr;
     connect = IO_OBJECT_NULL;
-    service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceNameMatching(pqrs::karabiner_virtual_hid_device::get_virtual_hid_root_name()));
+    service = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceNameMatching(pqrs::karabiner_virtual_hid_device::get_virtual_hid_root_name()));
     if (!service) {
         print_iokit_error("IOServiceGetMatchingService");
         return 1;

--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -9,7 +9,8 @@
 #include <AvailabilityMacros.h>
 
 /* The name was changed from "Master" to "Main" in Apple SDK 12.0 (Monterey) */
-#if !defined (MAC_OS_X_VERSION_12_0) || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_12_0)
+/* MAC_OS_X_VERSION_12_0 does not exist :( */
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 120000
     #define kIOMainPortDefault kIOMasterPortDefault
 #endif
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -283,22 +283,18 @@ and install `stack`
   $ brew install haskell-stack
 ```
 
-Then build kmonad with `stack`. If you are building against the kext, run:
+Then build kmonad with `stack` and install it to `~/.local/bin/`
+(which you may want to ensure is on your `PATH`).
+If you are building against the kext, run:
 
 ``` console
-  $ stack build --flag kmonad:kext --extra-include-dirs=c_src/mac/Karabiner-VirtualHIDDevice/dist/include
+  $ stack install --flag kmonad:kext --extra-include-dirs=c_src/mac/Karabiner-VirtualHIDDevice/dist/include
 ```
 
 If you are building against the dext, run
 
 ``` console
-  $ stack build --flag kmonad:dext --extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit:c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
-```
-
-Finally, run the following to place the executable `kmonad` in `~/.local/bin/` (which you may want to ensure is on your `PATH`)
-
-``` console
-  $ stack install
+  $ stack install --flag kmonad:dext --extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit:c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
 ```
 
 #### Giving kmonad additional permissions


### PR DESCRIPTION
This fixes #885.

It contained two problems:
1. `MAC_OS_X_VERSION_12_0` is not set (why? It was before).
2. The last `stack install` in the build instructions detects, that the flag `kmonad:dext` / `kmonad:kext` is not set and would recompile without it.

I could not test this PR since I don't have access to a mac. ~~(Therefore marked as Draft)~~

(sorry Github but I am testing this via the CI)