### PR TITLE
Hold instead of tapping when `multi-tap` gets interrupted during hold

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ### Changed
 
+- `multi-tap` now holds when interrupted by another key while held. (#897)
+
 ### Fixed
 
 ## 0.4.3 – 2024-09-11

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -499,7 +499,7 @@ multiTap l bs = onPress' tap' $ go bs
       -- 2B. If we do detect the release of the key that triggered this action,
       --     we must now keep waiting to detect another press.
       -- 2C. If we detect another (unrelated) press event we cancel the
-      --     remaining of the multi-tap sequence and trigger a tap on the
+      --     remaining of the multi-tap sequence and trigger a hold on the
       --     current button of the sequence.
       -- 3A. After 2B, if we do not detect a press before the interval is up,
       --     we know a tap occurred, so we tap the current button and we are
@@ -513,7 +513,7 @@ multiTap l bs = onPress' tap' $ go bs
       let doNext pred onTimeout next ms = tHookF InputHook ms onTimeout $ \t -> do
             pr <- pred
             if | pr (t^.event)      -> next (ms - t^.elapsed) $> Catch
-               | isPress (t^.event) -> tap b                  $> NoCatch
+               | isPress (t^.event) -> onTimeout              $> NoCatch
                | otherwise          -> pure NoCatch
       doNext (matchMy Release)
              (press b)


### PR DESCRIPTION
Fixes #486.