### PR TITLE
Fix tapping for `tapMacro` and `tapMacroRelease`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ### Fixed
 
+- Fixed `tapMacro` and `tapMacroRelease` behaviour which was slightly broken in #873 (#906)
+
 ## 0.4.3 – 2024-09-11
 
 ### Added

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -523,7 +523,7 @@ multiTap l bs = onPress' tap' $ go bs
 -- | Create a 'Button' that performs a series of taps on press. Note that the
 -- last button is only released when the tapMacro itself is released.
 tapMacro :: [Button] -> Button
-tapMacro bs = mkButton' (go True bs) (pure ()) (go False bs)
+tapMacro bs = mkButton' (go False bs) (pure ()) (go True bs)
   where
     go _ []      = pure ()
     go False [b]     = press b
@@ -533,7 +533,7 @@ tapMacro bs = mkButton' (go True bs) (pure ()) (go False bs)
 -- | Create a 'Button' that performs a series of taps on press,
 -- except for the last Button, which is tapped on release.
 tapMacroRelease :: [Button] -> Button
-tapMacroRelease bs = mkButton' (go True bs) (pure ()) (go False bs)
+tapMacroRelease bs = mkButton' (go False bs) (pure ()) (go True bs)
   where
     go _ []      = pure ()
     go False [b]     = awaitMy Release $ tap b >> pure Catch


### PR DESCRIPTION
Fixes #904.

I accidentily switched `True` and `False` in #873. We should really add tests to check for button behaviour, which is sadly a bit hard, if we don't want a test to require an IO action (heavy usage of `TMVar`s) (which it does anyway, since Spec wraps an IO monad) or want to have two distinct implementations of `MonadK`.

Sorry, I hope this was the last bug I introduced (at least in #873).

We could probably also do prereleases, which of course only makes sense if releases are more common.