### PR TITLE
Added `key-seq-delay`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Added more MacOS keys (#936)
 - Added keycodes above 255. If you are on linux you can use them now. (#935)
 - Added `boot.initrd.services.kmonad.enable` NixOS option to use KMonad in the initrd (#941).
+- Added `key-seq-delay`, a more general version of `cmp-seq-delay`, which enforces a minimum delay
+  after each key event. (#908)
 
 ### Changed
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -86,6 +86,8 @@ The following are all global config options that one can set in the
 + `cmp-seq-delay` (natural number): delay between each pressed key in a
   compose-key sequence.
 
++ `key-seq-delay` (natural number): delay between each outputted key event.
+
 + `implicit-around` (around variant, defaults to `around`):
   Specifies the variant of `around` to use in implicit around constructs
   like `A` or `S-a`.

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -108,6 +108,13 @@
     too rapidly; if you experience any problems in this direction, you can try
     setting this value to `5' or `10' and see if that helps.
 
+  - `key-seq-delay': NUMBER (in milliseconds)
+
+    This sets a delay between each outputted key event globally. Similarly to
+    `cmp-seq-delay` this may solve troubles caused by keys being ignored when
+    pressed to rapidly. You probably shouldn't specify both `cmp-seq-delay` and
+    `key-seq-delay`.
+
   Secondly, let's go over how to specify the `input` and `output` fields of a
   `defcfg` block. This differs between OSes, and so do the capabilities of
   these interfaces.
@@ -188,6 +195,7 @@
     "sleep 1 && setxkbmap -option compose:ralt")
   cmp-seq ralt    ;; Set the compose key to `RightAlt'
   cmp-seq-delay 5 ;; 5ms delay between each compose-key sequence press
+  key-seq-delay 5 ;; 5ms delay between each outputted key event
 
   ;; For Windows
   ;; input  (low-level-hook)

--- a/src/KMonad/App/Main.hs
+++ b/src/KMonad/App/Main.hs
@@ -101,7 +101,7 @@ initAppEnv cfg = do
     e <- atomically . takeTMVar $ otv
     emitKey snk e
     -- If delay is specified, wait for it
-    for_ (cfg^.keySeqDelay) $ threadDelay . (*1000) . fromIntegral
+    for_ (cfg^.keyOutDelay) $ threadDelay . (*1000) . fromIntegral
   -- emit e = view keySink >>= flip emitKey e
   pure $ AppEnv
     { _keAppCfg  = cfg

--- a/src/KMonad/App/Main.hs
+++ b/src/KMonad/App/Main.hs
@@ -100,6 +100,8 @@ initAppEnv cfg = do
   launch_ "emitter_proc" $ do
     e <- atomically . takeTMVar $ otv
     emitKey snk e
+    -- If delay is specified, wait for it
+    for_ (cfg^.keySeqDelay) $ threadDelay . (*1000) . fromIntegral
   -- emit e = view keySink >>= flip emitKey e
   pure $ AppEnv
     { _keAppCfg  = cfg

--- a/src/KMonad/App/Types.hs
+++ b/src/KMonad/App/Types.hs
@@ -51,6 +51,7 @@ data AppCfg = AppCfg
   , _fallThrough  :: Bool              -- ^ Whether uncaught events should be emitted or not
   , _allowCmd     :: Bool              -- ^ Whether shell-commands are allowed
   , _startDelay   :: Milliseconds      -- ^ How long to wait before acquiring the input keyboard
+  , _keySeqDelay  :: Maybe Milliseconds -- ^ How long to wait after each key event outputted
   }
 makeClassy ''AppCfg
 

--- a/src/KMonad/App/Types.hs
+++ b/src/KMonad/App/Types.hs
@@ -51,7 +51,7 @@ data AppCfg = AppCfg
   , _fallThrough  :: Bool              -- ^ Whether uncaught events should be emitted or not
   , _allowCmd     :: Bool              -- ^ Whether shell-commands are allowed
   , _startDelay   :: Milliseconds      -- ^ How long to wait before acquiring the input keyboard
-  , _keySeqDelay  :: Maybe Milliseconds -- ^ How long to wait after each key event outputted
+  , _keyOutDelay  :: Maybe Milliseconds -- ^ How long to wait after each key event outputted
   }
 makeClassy ''AppCfg
 

--- a/src/KMonad/Args.hs
+++ b/src/KMonad/Args.hs
@@ -46,6 +46,7 @@ loadConfig cmd = do
     , _fallThrough  = _flt     cgt
     , _allowCmd     = _allow   cgt
     , _startDelay   = _strtDel cmd
+    , _keySeqDelay  = fromIntegral <$> _ksd cgt
     }
 
 

--- a/src/KMonad/Args.hs
+++ b/src/KMonad/Args.hs
@@ -46,7 +46,7 @@ loadConfig cmd = do
     , _fallThrough  = _flt     cgt
     , _allowCmd     = _allow   cgt
     , _startDelay   = _strtDel cmd
-    , _keySeqDelay  = fromIntegral <$> _ksd cgt
+    , _keyOutDelay  = fromIntegral <$> _ksd cgt
     }
 
 
@@ -61,7 +61,7 @@ joinCLI cmd = traverse._KDefCfg %~ insertCliOption cliList
   cliList :: DefSettings
   cliList = catMaybes $
        map flagToMaybe [cmd^.cmdAllow, cmd^.fallThrgh]
-    <> [cmd^.iToken, cmd^.oToken, cmd^.cmpSeq, cmd^.implArnd]
+    <> [cmd^.iToken, cmd^.oToken, cmd^.cmpSeq, cmd^.cmpSeqDelay, cmd^.keySeqDelay, cmd^.implArnd]
 
   -- | Convert command line flags to a 'Maybe' type, where the non-presence, as
   -- well as the default value of a flag will be interpreted as @Nothing@

--- a/src/KMonad/Args/Cmd.hs
+++ b/src/KMonad/Args/Cmd.hs
@@ -45,6 +45,8 @@ data Cmd = Cmd
   , _cmdAllow  :: DefSetting       -- ^ Allow execution of arbitrary shell-commands?
   , _fallThrgh :: DefSetting       -- ^ Re-emit unhandled events?
   , _cmpSeq    :: Maybe DefSetting -- ^ Key to use for compose-key sequences
+  , _cmpSeqDelay :: Maybe DefSetting -- ^ Specify compose sequence key delays
+  , _keySeqDelay :: Maybe DefSetting -- ^ Specify key event output delays
   , _implArnd  :: Maybe DefSetting -- ^ How to handle implicit `around`s
   , _oToken    :: Maybe DefSetting -- ^ How to emit the output
   , _iToken    :: Maybe DefSetting -- ^ How to capture the input
@@ -84,6 +86,8 @@ cmdP =
       <*> cmdAllowP
       <*> fallThrghP
       <*> cmpSeqP
+      <*> cmpSeqDelayP
+      <*> keySeqDelayP
       <*> implArndP
       <*> oTokenP
       <*> iTokenP
@@ -141,6 +145,22 @@ cmpSeqP = optional $ SCmpSeq <$> option
   <> help "Which key to use to emit compose-key sequences"
   )
 
+-- | Specify compose sequence key delays.
+cmpSeqDelayP :: Parser (Maybe DefSetting)
+cmpSeqDelayP = optional $ SCmpSeqDelay <$> option (fromIntegral <$> megaReadM numP)
+  (  long  "cmp-seq-delay"
+  <> metavar "TIME"
+  <> help  "How many ms to wait between each key of a compose sequence"
+  )
+
+-- | Specify key event output delays.
+keySeqDelayP :: Parser (Maybe DefSetting)
+keySeqDelayP = optional $ SKeySeqDelay <$> option (fromIntegral <$> megaReadM numP)
+  (  long  "key-seq-delay"
+  <> metavar "TIME"
+  <> help  "How many ms to wait between each key event outputted"
+  )
+
 -- | How to handle implicit `around`s
 implArndP :: Parser (Maybe DefSetting)
 implArndP = optional $ SImplArnd <$> option
@@ -175,6 +195,7 @@ startDelayP = option (fromIntegral <$> megaReadM numP)
   (  long  "start-delay"
   <> short 'w'
   <> value 300
+  <> metavar "TIME"
   <> showDefaultWith (show . unMS )
   <> help  "How many ms to wait before grabbing the input keyboard (time to release enter if launching from terminal)")
 

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -182,6 +182,7 @@ joinConfig' = do
   o  <- getO
   ft <- getFT
   al <- getAllow
+  ksd <- getKeySeqDelay
 
   -- Extract the other blocks and join them into a keymap
   let als = extract _KDefAlias es
@@ -196,6 +197,7 @@ joinConfig' = do
     , _fstL  = fl
     , _flt   = ft
     , _allow = al
+    , _ksd   = ksd
     }
 
 --------------------------------------------------------------------------------
@@ -266,6 +268,15 @@ getCmpSeqDelay = do
     Right b        -> pure (Just b)
     Left None      -> pure Nothing
     Left Duplicate -> throwError $ DuplicateSetting "cmp-seq-delay"
+
+-- | Extract the key-seq-delay setting
+getKeySeqDelay :: J (Maybe Int)
+getKeySeqDelay = do
+  cfg <- oneBlock "defcfg" _KDefCfg
+  case onlyOne . extract _SKeySeqDelay $ cfg of
+    Right b        -> pure (Just b)
+    Left None      -> pure Nothing
+    Left Duplicate -> throwError $ DuplicateSetting "key-seq-delay"
 
 #ifdef linux_HOST_OS
 

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -400,7 +400,8 @@ joinButton ns als =
     -- Various compound buttons
     KComposeSeq bs     -> do csd <- getCmpSeqDelay
                              c   <- view cmpKey
-                             jst $ tapMacro . (c:) <$> isps bs csd
+                             csd' <- for csd $ go . KPause . fi
+                             jst $ tapMacro . (c:) . maybe id (:) csd' <$> isps bs csd
     KTapMacro bs mbD   -> jst $ tapMacro           <$> isps bs mbD
     KBeforeAfterNext b a -> jst $ beforeAfterNext <$> go b <*> go a
     KTapMacroRelease bs mbD ->

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -372,6 +372,7 @@ settingP = let f s p = symbol s *> p in
     , SFallThrough <$> f "fallthrough"   bool
     , SAllowCmd    <$> f "allow-cmd"     bool
     , SCmpSeqDelay <$> f "cmp-seq-delay" numP
+    , SKeySeqDelay <$> f "key-seq-delay" numP
     , SImplArnd    <$> f "implicit-around" implArndP
     ])
 

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -123,6 +123,7 @@ data CfgToken = CfgToken
   , _fstL  :: LayerTag                          -- ^ Name of initial layer
   , _flt   :: Bool                              -- ^ How to deal with unhandled events
   , _allow :: Bool                              -- ^ Whether to allow shell commands
+  , _ksd   :: Maybe Int                         -- ^ Output delay between keys
   }
 makeClassy ''CfgToken
 
@@ -187,6 +188,7 @@ data DefSetting
   | SFallThrough Bool
   | SAllowCmd    Bool
   | SCmpSeqDelay Int
+  | SKeySeqDelay Int
   | SImplArnd    ImplArnd
   deriving (Show)
 makeClassyPrisms ''DefSetting
@@ -201,6 +203,8 @@ instance Eq DefSetting where
   SFallThrough{} == SFallThrough{} = True
   SAllowCmd{}    == SAllowCmd{}    = True
   SImplArnd{}    == SImplArnd{}    = True
+  SCmpSeqDelay{} == SCmpSeqDelay{} = True
+  SKeySeqDelay{} == SKeySeqDelay{} = True
   _              == _              = False
 
 -- | A list of different 'DefSetting' values


### PR DESCRIPTION
Some applications drop key events if they happen to fast, with this option we can specify a delay between each key event send. This should fix #820, though I tested it against `fcitx5`, which had a similar problem.

Though While implementing this I noticed three problems with `cmp-seq-delay`:
1. Missing equality case (I fixed this)
2. Missing command line flags (I also fixed this)
3. No delay after the compose key (Did not fix, as I was unsure whether this was intended)

The third problem(?) is caused by the code in `Joiner` being:
```haskell
jst $ tapMacro . (c:) <$> isps bs csd
```
instead of
```haskell
jst $ tapMacro <$> isps (c:bs) csd
```

The choice to use `keyOutDelay` instead of `keySeqDelay` was only to circumvent name collisions.
I think we maybe want to consider merging my (very long) refactor PR (#896), as it merges the data structures using type families. Though I would still merge this one first, since I am then able to resolve the merge conflicts.