### PR TITLE
Fix keyrepeat not working in the tty

### DIFF
--- a/c_src/keyio.c
+++ b/c_src/keyio.c
@@ -21,6 +21,8 @@ int acquire_uinput_keysink(int fd, char *name, int vendor, int product, int vers
   for (i=0; i < 256; i++) {
     ioctl(fd, UI_SET_KEYBIT, i);
   }
+  // Enable key repeat for output keyboard
+  ioctl(fd, UI_SET_EVBIT, EV_REP);
 
   // Set the vendor details
   struct uinput_setup usetup;

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 - Fixed `tapMacro` and `tapMacroRelease` behaviour which was slightly broken in #873 (#906)
 - Fixed keycode translation problem on windows (#894)
+- Fixed keyrepeat not working in tty on linux (#913)
 
 ## 0.4.3 – 2024-09-11
 


### PR DESCRIPTION
Apparently we just needed to set an extra flag.
See [Blagus's comment](https://forums.raspberrypi.com/viewtopic.php?t=45041#p1066932) linking to [Using uinput driver in Linux-2.6.x](https://www.geocities.ws/gnumohan/Linux/uinput.txt).

Fixes #188. Though we should really be looking into implementing it in KMonad like #867 suggest.
Also fixes #543.