### PR TITLE
Implemented `tap-overlap` and `tap-hold-overlap`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 - Added names for the keys `rfkill` and `micmute` (#883).
   If you previously used the buttons `missing247` and `missing248`, please update to the new names.
+- Added `tap-overlap` and `tap-hold-overlap`, which could improve your shifting experience. (#916)
 
 ### Changed
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -348,6 +348,18 @@ to be the most comfortable.
   (defalias thr (tap-hold-next-release 1000 a sft))
   ```
 
++ `tap-overlap`: like `tap-next-release` but when the next release
+  is its own, we check if the temporal overlap between any currently
+  pressed button and this one is big enough.
+  The overlap is calculated by dividing the overlap by the total time
+  of the other button.
+
++ `tap-hold-overlap`: like `tap-overlap` with an additional timeout.
+
+  ```clojure
+  (defalias tho (tap-hold-overlap 1000 25 a sft))
+  ```
+
 + `tap-hold-next` and `tap-hold-next-release` can take an optional
   `:timeout-button` keyword to specify a button other than the
   hold button which should be held when the timeout expires.

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -909,6 +909,29 @@
   but it comes with an additional timeout that, just like `tap-hold-next` will
   jump into holding-mode after a timeout.
 
+  `tap-overlap` is like an upgraded version of `tap-next-release`.
+  When pressing a modifier and a button it is common to release them together,
+  though when releasing two keys at the same time the order, which matters
+  for `tap-next-release`, is abitrary.
+  To fix this this button takes another parameter which signals a hold if an
+  overlap percentage is met.
+  It is calculated by dividing the overlap time by the total time of a second
+  button (see below). If this value is bigger than the percentage given we hold.
+  In the case where the second button is completly surrounded (Pa Tb Ra) we
+  hold just like `tap-next-release`.
+
+    Pa Pb Ra Rb
+    --------       hold time of the `tap-overlap` button  a
+       --------    hold time of a different button        b
+       -----       overlap                                a ∩ b
+
+  The formula is: (a ∩ b)/b
+  Also keep in mind that this calculation produces a decimal value,
+  but we take a percentage as an argument (Use 50 instead of 0.5)
+
+  If you also want the hold behaviour of `tap-hold-next-release` you should
+  consider using `tap-hold-overlap` which takes a timeout as a first parameter.
+
   I honestly think that `tap-hold-next-release`, although it seems the most
   complicated, probably is the most comfortable to use. But I've put all of them
   in a testing layer down below, so give them a go and see what is nice.
@@ -923,6 +946,8 @@
   tnr (tap-next-release x lsft)
   tnp (tap-next-press x lsft)
   tnh (tap-hold-next-release 2000 x lsft)
+  tol (tap-overlap 80 x lsft)
+  tho (tap-hold-overlap 2000 80 x lsft)
 
   ;; Used it the colemak layer
   xcp (tap-hold-next 400 esc ctl)

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -354,6 +354,7 @@ joinButton ns als =
   let ret    = pure . Just
       go     = unnest . joinButton ns als
       jst    = fmap Just
+      fi :: Num a => Int -> a
       fi     = fromIntegral
       isps l = traverse go . maybe l ((`intersperse` l) . KPause . fi)
   in \case
@@ -402,6 +403,9 @@ joinButton ns als =
     KTapNextRelease t h -> jst $ tapNextRelease    <$> go t <*> go h
     KTapHoldNextRelease ms t h mtb
       -> jst $ tapHoldNextRelease (fi ms) <$> go t <*> go h <*> traverse go mtb
+    KTapOverlap pc t h -> jst $ tapOverlap (fi pc / 100) <$> go t <*> go h
+    KTapHoldOverlap ms pc t h mtb
+      -> jst $ tapHoldOverlap (fi ms) (fi pc / 100) <$> go t <*> go h <*> traverse go mtb
     KTapNextPress t h  -> jst $ tapNextPress       <$> go t <*> go h
     KAroundOnly o i    -> jst $ aroundOnly         <$> go o <*> go i
     KAroundWhenAlone o i -> jst $ aroundWhenAlone  <$> go o <*> go i

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -279,6 +279,10 @@ keywordButtons =
   , ("tap-hold-next-release"
     , KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP
                           <*> optional (keywordP "timeout-button" buttonP))
+  , ("tap-overlap", KTapOverlap <$> lexeme numP <*> buttonP <*> buttonP)
+  , ("tap-hold-overlap"
+    , KTapHoldOverlap <$> lexeme numP <*> lexeme numP <*> buttonP <*> buttonP
+                      <*> optional (keywordP "timeout-button" buttonP))
   , ("tap-next-press"
     , KTapNextPress <$> buttonP <*> buttonP)
   , ("tap-next"       , KTapNext     <$> buttonP     <*> buttonP)

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -71,6 +71,9 @@ data DefButton
   | KTapNextRelease DefButton DefButton    -- ^ Do 2 things based on behavior
   | KTapHoldNextRelease Int DefButton DefButton (Maybe DefButton)
     -- ^ Like KTapNextRelease but with a timeout
+  | KTapOverlap Int DefButton DefButton    -- ^ Do 2 things based on behavior
+  | KTapHoldOverlap Int Int DefButton DefButton (Maybe DefButton)
+    -- ^ Like KTapOverlap but with a timeout
   | KTapNextPress DefButton DefButton      -- ^ Like KTapNextRelease but also hold on presses
   | KAroundNext DefButton                  -- ^ Surround a future button
   | KAroundNextSingle DefButton            -- ^ Surround a future button

--- a/src/KMonad/Util.hs
+++ b/src/KMonad/Util.hs
@@ -19,6 +19,7 @@ module KMonad.Util
   , tDiff
 
     -- * Random utility helpers that have no better home
+  , Percentage(..)
   , onErr
   , using
   , logRethrow
@@ -44,6 +45,10 @@ import Data.Time.Clock.System
 -- | Newtype wrapper around 'Int' to add type safety to our time values
 newtype Milliseconds = Milliseconds { unMS :: Int }
   deriving (Eq, Ord, Num, Real, Enum, Integral, Show, Read, Generic, Display, Typeable, Data)
+
+-- | Like 'Milliseconds' but for percentages using 'Float'
+newtype Percentage = Percentage { unPC :: Float }
+  deriving (Eq, Ord, Num, Real, Fractional, RealFrac, Show, Read, Generic, Display, Typeable, Data)
 
 -- | Calculate how much time has elapsed between 2 time points
 tDiff :: ()


### PR DESCRIPTION
A slightly improved version of `tap-hold-next-release`, for the common case where you release modifier and key and roughly the same time, which may or may not cause a tap ordering.

This button checks if the other button has enough overlap with the currently pressed one (for details see the changes in the tutorial) and then holds

fixes #910