### PR TITLE
Update HLint workflow

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -9,15 +9,15 @@ jobs:
   hlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: 'Set up HLint'
-      uses: haskell/actions/hlint-setup@v2
+      uses: haskell-actions/hlint-setup@v2
       with:
         version: '3.5'
 
     - name: 'Run HLint'
-      uses: haskell/actions/hlint-run@v2
+      uses: haskell-actions/hlint-run@v2
       with:
         path: '["src/", "test/", "app/"]'
         fail-on: status


### PR DESCRIPTION
We get a warning that GitHub forces node 20 on us. Why not just update?