### PR TITLE
Mention `evdev` in the docs as a requirement

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -4,6 +4,7 @@
 - [Linux](#linux)
     - [Q: How do I get Uinput permissions?](#q-how-do-i-get-uinput-permissions)
     - [Q: How do I know which event-file corresponds to my keyboard?](#q-how-do-i-know-which-event-file-corresponds-to-my-keyboard)
+        - [Q: `/dev/input` does not exist?](#q-dev-input-does-not-exist)
     - [Q: How do I emit Hyper_L?](#q-how-do-i-emit-hyper_l)
     - [Q: How does Unicode entry work?](#q-how-does-unicode-entry-work)
     - [Q: How do I use the same layout definition for different keyboards?](#q-how-do-i-use-the-same-layout-definition-for-different-keyboards)
@@ -67,6 +68,11 @@ A: By far the best solution is to use the keyboard devices listed
 under `/dev/input/by-id`. In some case, you could also try
 `/dev/input/by-path`. If you can't figure out which file just by
 the filenames, the `evtest` program is very helpful.
+
+#### Q: `/dev/input` does not exist?
+
+A: This may be due to the kernel module `evdev` not being loaded.
+Try to run `sudo modprobe evdev`.
 
 ### Q: How do I emit Hyper_L?
 

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -124,6 +124,8 @@
   NOTE: Any valid path to a device-file will work, but it is recommended to use
   the 'by-id' directory, since these names will not change if you replug the
   device.
+  If the '/dev/input' directory does for any reason not exists (i.e. maybe in the
+  initramfs) it could be due to the 'evdev' kernel module not being loaded.
 
   We deal with output by creating a 'uinput' device. This requires that the
   'uinput' kernel module is loaded. The easiest way to ensure this is by calling


### PR DESCRIPTION
This is mainly relevant when trying to get KMonad to work in the initramfs (as I do).

This is mostly not a problem, since [programs are encouraged by the kernel docs](https://www.kernel.org/doc/html/latest/input/input.html#evdev) to use the API provided by it.

I encountered problems when trying out NixOS and wanted to document it.