### PR TITLE
[macOS] Upgrade Karabiner-DriverKit-VirtualHIDDevice to v5.0.0

### DIFF
--- a/c_src/mac/dext.cpp
+++ b/c_src/mac/dext.cpp
@@ -23,10 +23,13 @@ int init_sink() {
     /**/
     client->connected.connect([copy] {
                                   std::cout << "connected" << std::endl;
-                                  copy->async_virtual_hid_keyboard_initialize(pqrs::hid::country_code::us);
+                                  pqrs::karabiner::driverkit::virtual_hid_device_service::virtual_hid_keyboard_parameters parameters;
+                                  parameters.set_country_code(pqrs::hid::country_code::us);
+                                  copy->async_virtual_hid_keyboard_initialize(parameters);
                               });
     client->connect_failed.connect([](auto&& error_code) {
                                        std::cout << "connect_failed " << error_code << std::endl;
+                                       std::cout << "You may need to start Karabiner" << std::endl;
                                    });
     client->closed.connect([] {
                                std::cout << "closed" << std::endl;

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### Added
 
 ### Changed
+- Update Karabiner-DriverKit to 5.0.0 (#937)
+  You will now need to [start the server yourself](doc/installation.md#starting-the-dext-daemon).
 
 ### Fixed
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -338,8 +338,8 @@ Simply run these commands in Windows PowerShell:
 
 KMonad supports macOS 10.12 to 10.15 (Sierra, High Sierra, Mojave, and
 Catalina) and macOS 11.0 (Big Sur). When using driverkit-based extension
-v2.1.0 and later, KMonad also supports macOS 13.0 (Ventura) and 14.0
-(Sonoma).
+v5.0.0 and later, KMonad also supports macOS 13.0 (Ventura), 14.0
+(Sonoma) and 15.0 (Sequoia).
 
 Note: Under macOS, `kmonad` uses one of two "system extensions" to
 post modified key events to the OS. For macOS Catalina and prior, we
@@ -396,7 +396,7 @@ Therefore, if you use Karabiner-Elements, you may already have the
 dext installed (though maybe a different version number). Run
 `defaults read
 /Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/Info.plist
-CFBundleVersion` to check the version: if `3.1.0` is shown, then the
+CFBundleVersion` to check the version: if `5.0.0` is shown, then the
 installed dext is compatible with kmonad and you can move onto
 [installing kmonad](#installing-kmonad). If another version is listed,
 this may work too (but has not been tested).
@@ -419,7 +419,7 @@ install the extension, and activate the extension.
 
 ```console
   $ cd kmonad/
-  $ open c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/dist/Karabiner-DriverKit-VirtualHIDDevice-3.1.0.pkg
+  $ open c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/dist/Karabiner-DriverKit-VirtualHIDDevice-5.0.0.pkg
 ```
 
 ```console
@@ -431,6 +431,17 @@ If it still doesn't work you need to
 [temporarly disable System Integrity Protection](https://developer.apple.com/documentation/security/disabling-and-enabling-system-integrity-protection)
 for installation.
 
+##### Starting the dext daemon
+
+Starting with version 4.0.0, the dext installation no longer manages the daemon for the Karabiner-DriverKit-VirtualHIDDevice. Users are now required to start the daemon manually:
+
+```console
+  $ sudo '/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon'
+```
+
+A [Launch Agent Property List (plist file)](https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/blob/v5.0.0/files/LaunchDaemons/org.pqrs.service.daemon.Karabiner-VirtualHIDDevice-Daemon.plist)
+is provided in the Karabiner-DriverKit-VirtualHIDDevice repository,
+which can be used to start the daemon automatically at login.
 
 #### Installing kmonad
 

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -150,7 +150,7 @@ library
         -std=c++2a
       include-dirs:
         c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit
-        c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
+        c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Daemon/vendor/include
     extra-libraries:
       c++
     build-depends:


### PR DESCRIPTION
This PR upgrades Karabiner-DriverKit-VirtualHIDDevice to version v5.0.0.

## Improvements
Starting with version **v4.0.0**, Karabiner-DriverKit ensures binary compatibility for client applications. As a result, kmonad no longer need to be recompiled when upgrading Karabiner-DriverKit.

## Key Changes

### macOS Compatibility:
Support for macOS 12 and earlier versions has been discontinued.

### Daemon Management:
- As of v5.0.0, Karabiner-DriverKit requires the daemon to be explicitly managed by the user.  
- The installation now includes:
  - A requirement to start the daemon for dext.
  - Link to the plist file for autostart daemon using `launchd`.