### PR TITLE
Deduplicate compose sequence and added more tests

### DIFF
--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -183,6 +183,7 @@ test-suite spec
       KMonad.ButtonDocSpec
       KMonad.GestureSpec
       KMonad.ComposeSeqSpec
+      KMonad.KeycodeSpec
   default-language:
       Haskell2010
   build-tool-depends: hspec-discover:hspec-discover == 2.*

--- a/src/KMonad/Keyboard/ComposeSeq.hs
+++ b/src/KMonad/Keyboard/ComposeSeq.hs
@@ -734,8 +734,6 @@ ssComposed = composeSeqs & (each . _1) %~ sanitize
     , ("_ '"      , '⍘'     , "U2358")
     , ("0 ~"      , '⍬'     , "U236c")
     , ("| ~"      , '⍭'     , "U236d")
-    , ("< _"      , '≤'     , "U2264")
-    , ("> _"      , '≥'     , "U2265")
 
     -- Sequences that should exist but do not work
     --, ("` spc"    , '`'     , "grave") -- recursive and incorrect. It's <dead_grave> <space> and <dead_grave> is not mapped in en_US

--- a/test/KMonad/ComposeSeqSpec.hs
+++ b/test/KMonad/ComposeSeqSpec.hs
@@ -9,11 +9,20 @@ import KMonad.Prelude
 
 import Test.Hspec
 
+import qualified RIO.NonEmpty as N
 import qualified RIO.Text as T
 
 spec :: Spec
-spec = describe "compose-sequences" $ traverse_ checkComposeSeq ssComposed
+spec = describe "compose-sequences" $ do
+  traverse_ checkComposeSeq ssComposed
+  noDuplicates
  where
+  noDuplicates = describe "No duplicate compose sequence definitions" $ do
+    noDuplicates' _1 "Compose sequences"
+    noDuplicates' _2 "Characters"
+    noDuplicates' _3 "Character names"
+  noDuplicates' field desc = it desc $ duplicates (view field) ssComposed `shouldBe` []
+  duplicates field = filter (not . null . N.tail) . N.groupAllWith field
   checkComposeSeq (expected, c, name) = describe ("Compose sequence for " <> unpack name) $ do
     let c' = T.singleton c
     let actualSeq = runParser buttonP "" c'

--- a/test/KMonad/KeycodeSpec.hs
+++ b/test/KMonad/KeycodeSpec.hs
@@ -1,0 +1,16 @@
+module KMonad.KeycodeSpec (spec) where
+
+import KMonad.Keyboard.Keycode (keyNames)
+import KMonad.Util.MultiMap as Q
+import KMonad.Prelude
+
+import qualified RIO.NonEmpty as N
+
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  let dups = filter (not . null . N.tail) $ N.groupAllWith snd (keyNames ^.. Q.itemed)
+
+  it "No duplicate keycode names" $
+    dups `shouldBe` []


### PR DESCRIPTION
Added a test for keycode duplicate naming and removed unnecessary compose sequence (defined twice).