### PR TITLE
Added option to enable KMonad in the initrd for NixOS

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
   If you previously used the buttons `missing247` and `missing248`, please update to the new names.
 - Added more MacOS keys (#936)
 - Added keycodes above 255. If you are on linux you can use them now. (#935)
+- Added `boot.initrd.services.kmonad.enable` NixOS option to use KMonad in the initrd (#941).
 
 ### Changed
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -167,10 +167,7 @@ in
       isSystemUser = true;
     };
 
-    services.udev.extraRules = ''
-      # KMonad user access to /dev/uinput
-      KERNEL=="uinput", MODE="0660", GROUP="uinput", OPTIONS+="static_node=uinput"
-    '';
+    hardware.uinput.enable = true;
 
     systemd.paths =
       builtins.listToAttrs

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -51,7 +51,8 @@ let
 
           delay = lib.mkOption {
             type = lib.types.ints.unsigned;
-            default = 5;
+            default = 0;
+            example = 5;
             description = "The delay (in milliseconds) between compose key sequences.";
           };
         };


### PR DESCRIPTION
While I'm at it, this also fixes the descriptions of the options.

Furthermore we change the `cmp-seq-delay` default, to the one from KMonad.

Though a default of 0 is a bit wierd, since something like 5 has no real drawback but fixes issues. Personally I would be in favor of increasing it (from 0) or even better use #908 instead.

Will make a PR for it, but github cannot do dependent PRs, so this will wait till #908 is merged.

Sorry for mixing multiple things in the same PR