### PR TITLE
Fix `tutorial.kbd` post-init command

### DIFF
--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -183,7 +183,7 @@
   output (uinput-sink "My KMonad output"
     ;; To understand the importance of the following line, see the section on
     ;; Compose-key sequences at the near-bottom of this file.
-    "/run/current-system/sw/bin/sleep 1 && /run/current-system/sw/bin/setxkbmap -option compose:ralt")
+    "sleep 1 && setxkbmap -option compose:ralt")
   cmp-seq ralt    ;; Set the compose key to `RightAlt'
   cmp-seq-delay 5 ;; 5ms delay between each compose-key sequence press
 


### PR DESCRIPTION
Since it gets executed by `/bin/sh -c` we don't need an absolute path.
Furthermore this aligns it with how the `quick-reference.md` does it.
Fixes #942