### PR TITLE
Fix windows and reenable CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest
             , macos-latest
-            # , windows-latest
+            , windows-latest
             ]
         resolver:
           [ lts-20               # GHC 9.2

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -13,16 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest
-            , macos-latest
-            , windows-latest
-            ]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         resolver:
-          [ lts-20               # GHC 9.2
-          , lts-21               # GHC 9.4
-          , lts-22               # GHC 9.6
-          , nightly-2024-07-05   # GHC 9.8
-          ]
+          - lts-20               # GHC 9.2
+          - lts-21               # GHC 9.4
+          - lts-22               # GHC 9.6
+          - nightly-2024-07-05   # GHC 9.8
 
     steps:
       - name: Clone project

--- a/c_src/keyio_win.c
+++ b/c_src/keyio_win.c
@@ -80,6 +80,7 @@ LRESULT CALLBACK keyHandler(int nCode, WPARAM wParam, LPARAM lParam)
   // Write the event to the pipe
   DWORD dwWritten;
   WriteFile(writePipe, &ev, sizeof(ev), &dwWritten, NULL);
+  return 1; // Block others from handeling. Since they should only use KMonad output
 }
 
 // Read an event from the pipe and write it to the provided pointer
@@ -92,7 +93,7 @@ void wait_key(struct KeyEvent* e)
 }
 
 // Insert the keyboard hook and start the monitoring process
-int grab_kb()
+void grab_kb()
 {
   // Insert the hook, error on failure
   hookHandle = SetWindowsHookEx(WH_KEYBOARD_LL, keyHandler, NULL, 0);

--- a/src/KMonad/Keyboard/IO/Windows/LowLevelHookSource.hs
+++ b/src/KMonad/Keyboard/IO/Windows/LowLevelHookSource.hs
@@ -27,7 +27,7 @@ import KMonad.Keyboard.IO.Windows.Types
 
 -- | Use the windows c-api to `grab` a keyboard
 foreign import ccall "grab_kb"
-  grab_kb :: IO Word8
+  grab_kb :: IO ()
 
 -- | Release the keyboard hook
 foreign import ccall "release_kb"
@@ -43,7 +43,7 @@ foreign import ccall "wait_key"
 
 -- | Data used to track `connection` to windows process
 data LLHook = LLHook
-  { _thread :: !(Async Word8)        -- ^ The thread-id of the listen-process
+  { _thread :: !(Async ())        -- ^ The thread-id of the listen-process
   , _buffer :: !(Ptr WinKeyEvent) -- ^ Buffer used to communicate with process
   }
 makeLenses ''LLHook

--- a/src/KMonad/Keyboard/IO/Windows/Types.hs
+++ b/src/KMonad/Keyboard/IO/Windows/Types.hs
@@ -29,7 +29,8 @@ import KMonad.Keyboard
 import Data.Tuple (swap)
 import qualified RIO.HashMap as M
 import qualified RIO.NonEmpty as NE (groupAllWith)
-import qualified Data.Foldable (minimumBy, maximumBy)
+-- TODO: use `Data.Foldable1` instead when `base` >= 4.18.0.0
+import qualified Data.Foldable as NE (minimumBy, maximumBy)
 
 ----------------------------------------------------------------------------
 -- $err
@@ -126,7 +127,7 @@ fromWinKeyEvent (WinKeyEvent (s, c)) = case fromWinKeycode c of
 -- FIXME: There are loads of missing correspondences, mostly for rare-keys. How
 -- do these line up? Ideally this mapping would be total.
 winCodeToKeyCode :: M.HashMap WinKeycode Keycode
-winCodeToKeyCode = M.fromList $ minimumBy (compare `on` snd) <$> NE.groupAllWith fst winCodeKeyCodeMapping
+winCodeToKeyCode = M.fromList $ NE.minimumBy (compare `on` snd) <$> NE.groupAllWith fst winCodeKeyCodeMapping
 
 -- | Translate a KMonad KeyCode to the corresponding Windows virtual-key code
 --
@@ -134,7 +135,7 @@ winCodeToKeyCode = M.fromList $ minimumBy (compare `on` snd) <$> NE.groupAllWith
 -- there will be duplicates where more than one virtual-key code produces the
 -- same KMonad KeyCode. See https://github.com/kmonad/kmonad/issues/326
 keyCodeToWinCode :: M.HashMap Keycode WinKeycode
-keyCodeToWinCode = M.fromList $ swap . maximumBy (compare `on` fst) <$> NE.groupAllWith snd winCodeKeyCodeMapping
+keyCodeToWinCode = M.fromList $ swap . NE.maximumBy (compare `on` fst) <$> NE.groupAllWith snd winCodeKeyCodeMapping
 
 -- | A table of which virtual-key code from Windows
 -- correspond to which KMonad KeyCode.


### PR DESCRIPTION
While merging #894 it seems the windows code was broken.
To detect this in the future we reenable the windows CI (cherry-picked from #896)
and fixed some warnings (also cherry picked + part of other commit).

While we're touching the CI, we also made the lists more uniform for cleaner diffs in the future

Fixes #946.