### PR TITLE
Rework changelog to use git trailers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### Description
+
+Include a description for your changes, including the motivation behind them.
+
+### Checklist
+
+- [ ] I've read [CONTRIBUTING.md](https://github.com/kmonad/kmonad/blob/master/CONTRIBUTING.md)
+- [ ] I added a changelog entry as described in [Add a Changelog entry](https://github.com/kmonad/kmonad/blob/master/CONTRIBUTING.md#add-a-changelog-entry)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,25 @@ request:
 - A brief summary of how your commits fit together to achieve this (if
   necessary).
 
-Please also remember to update the `CHANGELOG.md` file, as well as any other
-documentation that your pull request touches upon.  For example, when
-implementing a new feature, you should update the `tutorial.kbd` file
-accordingly.
+Please also remember to update any documentation that your pull request touches
+upon.  For example, when implementing a new feature, you should update the
+`tutorial.kbd` file accordingly.
+
+### Add a Changelog entry
+
+Please also remember to add the changelog entry.
+To reduce merge conflicts, we use `git-interpret-trailers`.
+Simply add a trailer with either `Added`, `Changed`, `Fixed` or `Breaking`.
+
+A full commit message may then look like the following:
+
+```gitcommit
+Added `key-seq-delay`
+
+Some applications drop key events if they happen to fast,
+with this option we can specify a delay between each key event send.
+
+Added: Added `key-seq-delay` option to `defcfg`.
+  If you have problems with missing key events in some apps,
+  consider adding `key-seq-delay 5` to your `defcfg`
+```

--- a/tools/generate-release-changelog.sh
+++ b/tools/generate-release-changelog.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu
+
+log() { printf "$@" >&2; }
+
+lastRelease=${1:-$(git tag --list --sort -version:refname | head -n1)}
+
+log 'Last release is `%s`.\n' "$lastRelease"
+
+get-changelog-entries() {
+	# We format manually via `sed`, since trailers contain trailing newlines
+	entries=$(git log HEAD..."$lastRelease" \
+		-z --format="%h%x09%(trailers:valueonly,key=$1)" \
+		| sed -zne 's/^\([0-9a-f]\+\)\t\(.\+\)\n$/- \2 (\1)/p' \
+		| tr '\0' '\n')
+
+	if [[ -z "$entries" ]] then return; fi
+
+	printf '\n### %s\n\n' "$1"
+	printf '%s\n' "$entries"
+}
+
+printf '## Unreleased\n'
+get-changelog-entries Breaking
+get-changelog-entries Added
+get-changelog-entries Changed
+get-changelog-entries Fixed


### PR DESCRIPTION
The current changelog system as used by others is to ignore `changelog.md` entirely.
This leads to a lot of work when making a new release.

The changelog system documented in `CONTRIBUTING.md` leads to lots of mergeconflicts.
But has the benefit of reducing the work when making releases.

Instead of those systems, I propose to use git trailers and automatically extract the changelog from them.

Transitioning will require some manual work:
1. Open pull requests need to be handled (I.e. either they add the changelog entry, or it has to be done after merging)
    Currently only #937 is missing one from the newer ones.
2. The first release needs to merge the `Unreleased` section with the generated entries.