### PR TITLE
Hold while `multi-tap` is undecided

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed `tapMacro` and `tapMacroRelease` behaviour which was slightly broken in #873 (#906)
 - Fixed keycode translation problem on windows (#894)
 - Fixed keyrepeat not working in tty on linux (#913)
+- Fixed `multi-tap` not holding (#958)
 
 ## 0.4.3 – 2024-09-11
 

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -483,14 +483,14 @@ tapNextPress t h = onPress' t go
 -- into its list. The moment a delay is exceeded or immediately upon reaching
 -- the last button, that button is pressed.
 multiTap :: Button -> [(Milliseconds, Button)] -> Button
-multiTap l bs = onPress' tap' $ go bs
+multiTap l bs = onPress' tap' $ hold True *> go bs
   where
     tap' = case bs of
       []           -> l
       ((_, b) : _) -> b
 
     go :: [(Milliseconds, Button)] -> AnyK ()
-    go []            = press l
+    go []            = press l *> hold False
     go ((ms, b):bs') = do
       -- This is a bit complicated. What we do is:
       -- 1.  We wait for an event
@@ -514,10 +514,10 @@ multiTap l bs = onPress' tap' $ go bs
             pr <- pred
             if | pr (t^.event)      -> next (ms - t^.elapsed) $> Catch
                | isPress (t^.event) -> onTimeout              $> NoCatch
-               | otherwise          -> pure NoCatch
+               | otherwise          -> hold False             $> NoCatch
       doNext (matchMy Release)
-             (press b)
-             (doNext (matchMy Press) (tap b) (\_ -> go bs'))
+             (press b *> hold False)
+             (doNext (matchMy Press) (tap b *> hold False) (\_ -> go bs'))
              ms
 
 -- | Create a 'Button' that performs a series of taps on press. Note that the


### PR DESCRIPTION
Fixes #955.

If we merge #524 (or #914). We should change `InputHook` to `InputHookPrio`.
Furthermore this breaks the last button being held the same length the key is held (See [this comment](https://github.com/kmonad/kmonad/pull/524#issuecomment-2614028429) for details).
To fix this we could reimplement `press` using `InputHookPrio` or change #524 as suggested.