### PR TITLE
Simplify installation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,15 +7,27 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - linux
+          - windows
     steps:
 
-      - uses: actions/checkout@v4
+      - name: Clone project
+        uses: actions/checkout@v4
 
-      - run: docker build . -t kmonad-builder
+      - name: Build release
+        run: docker build -f ci/Dockerfile.${{ matrix.target }} . -t kmonad-builder
 
-      - run: docker run --rm -v ${PWD}:/host/ kmonad-builder bash -c 'cp -vp /root/.local/bin/kmonad /host/'
+      - name: Save binary
+        run: |
+          mkdir output
+          docker run --rm -v ${PWD}/output:/host/ kmonad-builder bash -c 'cp -vp /output/* /host/'
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
         with:
-          name: kmonad-binary
-          path: kmonad
+          name: kmonad-${{ matrix.target }}
+          path: 'output/*'

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -97,7 +97,6 @@ jobs:
             --fast --no-terminal \
             --resolver=${{ matrix.resolver }} --system-ghc \
             --flag kmonad:dext \
-            --extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit:c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
 
       - name: Build and test (macOS, kext)
         shell: bash
@@ -106,4 +105,4 @@ jobs:
           stack test \
             --fast --no-terminal \
             --resolver=${{ matrix.resolver }} --system-ghc \
-            --flag kmonad:kext --extra-include-dirs=c_src/mac/Karabiner-VirtualHIDDevice/dist/include
+            --flag kmonad:kext

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
+# syntax=docker/dockerfile:1.7-labs
 FROM lierdakil/alpine-haskell:9.4.8
 
 WORKDIR /usr/src/kmonad/
 RUN apk --no-cache add git
 RUN stack update
 
-COPY ./kmonad.cabal ./stack.yaml ./
-RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies --ghc-options="-fPIC"
-COPY ./ ./
-RUN sed -i '/executable kmonad/ a\  ld-options: -static' kmonad.cabal && \
-  stack --no-install-ghc --system-ghc --skip-ghc-check install --ghc-options="-j -fPIC"
+COPY stack.yaml kmonad.cabal ./
+# We edit the `stack.yaml` file instead of passing `--ghc-options`,
+# since we want to apply those options to all packages. Not just KMonad.
+RUN sed -i '/ghc-options/ a\  $everything: -fPIC -split-sections' stack.yaml
+RUN sed -i '/executable kmonad/ a\  ld-options: -static' kmonad.cabal
+RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies
+
+COPY --exclude=stack.yaml --exclude=kmonad.cabal ./ ./
+RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 install --ghc-options=-j

--- a/ci/Dockerfile.linux
+++ b/ci/Dockerfile.linux
@@ -8,7 +8,7 @@ RUN stack update
 COPY stack.yaml kmonad.cabal ./
 # We edit the `stack.yaml` file instead of passing `--ghc-options`,
 # since we want to apply those options to all packages. Not just KMonad.
-RUN sed -i '/ghc-options/ a\  $everything: -fPIC -split-sections' stack.yaml
+RUN sed -i '/ghc-options/ a\  $everything: -split-sections' stack.yaml
 RUN sed -i '/executable kmonad/ a\  ld-options: -static' kmonad.cabal
 RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies
 

--- a/ci/Dockerfile.linux
+++ b/ci/Dockerfile.linux
@@ -13,4 +13,5 @@ RUN sed -i '/executable kmonad/ a\  ld-options: -static' kmonad.cabal
 RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 build --only-dependencies
 
 COPY --exclude=stack.yaml --exclude=kmonad.cabal ./ ./
-RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 install --ghc-options=-j
+RUN stack --no-install-ghc --system-ghc --skip-ghc-check -j8 install --ghc-options=-j \
+	--local-bin-path=/output

--- a/ci/Dockerfile.windows
+++ b/ci/Dockerfile.windows
@@ -1,0 +1,50 @@
+# Copyright (c) Joschua Kesper, 2024
+
+FROM debian:12
+
+WORKDIR /haskell
+
+#RUN dpkg --add-architecture i386
+RUN apt-get update
+RUN apt-get install --no-install-recommends --assume-yes \
+  ca-certificates unzip xz-utils \
+  wine winbind
+
+ADD https://downloads.haskell.org/~cabal/cabal-install-3.12.1.0/cabal-install-3.12.1.0-x86_64-windows.zip cabal.zip
+ADD https://downloads.haskell.org/~ghc/9.6.6/ghc-9.6.6-x86_64-unknown-mingw32.tar.xz ghc.tar.xz
+ADD https://curl.se/windows/latest.cgi?p=win64-mingw.zip curl.zip
+
+# Wine provides an outdated powershell, which breaks cabal (See https://github.com/haskell/cabal/issues/4747).
+# We decide to install `curl` instead of using `http`.
+RUN unzip cabal.zip cabal.exe
+# We strip the prefix containing the ghc version to be more generic
+RUN tar -xJf ghc.tar.xz --strip-components=1
+# Same for curl.
+RUN unzip -j curl.zip curl-*/bin/curl.exe -d bin
+ENV WINEPATH=Z:\\haskell\\bin
+
+#ENV WINEDEBUG=-all
+RUN wine cabal.exe update
+
+WORKDIR /usr/src/kmonad
+COPY stack.yaml kmonad.cabal ./
+
+# ===== NOTE ON CABAL USAGE =====
+# We don't use stack, since MSYS2 is broken under wine.
+# Therefore we get cabal to use stackage
+
+# ===== NOTE ON BINARY SIZE =====
+# `--split-sections` does not seem to do anything,
+# but stripping does do a lot.
+RUN sed -n \
+	-e '$a \packages: .' \
+	-e '$a \executable-stripping: true' \
+	-e '$a \package *' \
+	-e '$a \  split-sections: true' \
+	-e 's|resolver:\s\+\(\S\+\)|import: https://www.stackage.org/\1/cabal.config|p' \
+	stack.yaml > cabal.project
+
+RUN wine /haskell/cabal.exe build -j8 --only-dependencies
+
+COPY ./ ./
+RUN wine /haskell/cabal.exe install -j8 --install-method=copy --installdir='Z:/output'

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -448,14 +448,14 @@ If you are building against the kext, run:
 
 ``` console
   $ cd kmonad/
-  $ stack install --flag kmonad:kext --extra-include-dirs=c_src/mac/Karabiner-VirtualHIDDevice/dist/include
+  $ stack install --flag kmonad:kext
 ```
 
 If you are building against the dext, run
 
 ``` console
   $ cd kmonad/
-  $ stack install --flag kmonad:dext --extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit:c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
+  $ stack install --flag kmonad:dext
 ```
 
 #### Giving kmonad additional permissions

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -140,11 +140,16 @@ library
         c_src/mac/kext.cpp
       cxx-options:
         -std=c++14
+      include-dirs:
+        c_src/mac/Karabiner-VirtualHIDDevice/dist/include
     if flag(dext)
       cxx-sources:
         c_src/mac/dext.cpp
       cxx-options:
         -std=c++2a
+      include-dirs:
+        c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit
+        c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include
     extra-libraries:
       c++
     build-depends:

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,4 @@ packages:
 - .
 extra-deps:
 pvp-bounds: both
+ghc-options:


### PR DESCRIPTION
Cherry-picked from #896. With some squashing.

Simplify installation by:
- reducing the binary size
- providing a docker image for windows.
  since this is designed to run on linux it's help is limited for windows users.
  It's real purpose is to allow generation of windows release binaries as often requested.
  (fixes #932)
- Provide flags for compilation on macos in `cabal` file.

The windows dockerfile sometimes errors while building a random package.
Hopefully ghc will become runtime retargetable soon.
Alternatively we could build our own cross compiler, but that would greatly increase compile time.
Furthermore the `TemplateHaskell` code would cause some problems.