### PR TITLE
Fix NixOS install instructions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -121,7 +121,7 @@ instead of a manual configuration.
 
    ``` nix
    kmonad = {
-     url = "git+https://github.com/kmonad/kmonad?submodules=1&dir=nix";
+     url = "github:kmonad/kmonad?dir=nix";
      inputs.nixpkgs.follows = "nixpkgs";
    };
    ```


### PR DESCRIPTION
We simplify the install url, since `submodules` seems broken and is unneeded anyway.

Fixes #961.

Btw. was `submodules` every documented anywhere? All I could find is random discussion threads.
No actual documentation.