### PR TITLE
Fixed exit on untranslateable keycode on macos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed `tapMacro` and `tapMacroRelease` behaviour which was slightly broken in #873 (#906)
 - Fixed keycode translation problem on windows (#894)
 - Fixed keyrepeat not working in tty on linux (#913)
-- Fixed unrecognized keycodes on macos closing KMonad (#966)
+- Fixed unrecognized events on macos closing KMonad (#966)
 
 ## 0.4.3 – 2024-09-11
 

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed `tapMacro` and `tapMacroRelease` behaviour which was slightly broken in #873 (#906)
 - Fixed keycode translation problem on windows (#894)
 - Fixed keyrepeat not working in tty on linux (#913)
+- Fixed unrecognized keycodes on macos closing KMonad (#966)
 
 ## 0.4.3 – 2024-09-11
 

--- a/src/KMonad/Keyboard/IO/Mac/IOKitSource.hs
+++ b/src/KMonad/Keyboard/IO/Mac/IOKitSource.hs
@@ -80,12 +80,7 @@ iokitRead b = do
     peek $ b^.buffer
   case fromMacKeyEvent we of
     Nothing -> iokitRead b
-    Just (Left e)
-      | (`all` e) $ \case
-        NoMacKeycodeFrom _ -> True
-        _ -> False
-      -> do
-        for_ e (logDebug . displayShow)
-        iokitRead b
-      | otherwise -> throwIO e
+    Just (Left e) -> do
+      for_ e (logDebug . displayShow)
+      iokitRead b
     Just (Right k)  -> pure k

--- a/src/KMonad/Keyboard/IO/Mac/IOKitSource.hs
+++ b/src/KMonad/Keyboard/IO/Mac/IOKitSource.hs
@@ -80,4 +80,12 @@ iokitRead b = do
     peek $ b^.buffer
   case fromMacKeyEvent we of
     Nothing -> iokitRead b
-    Just e  -> either throwIO pure e
+    Just (Left e)
+      | (`all` e) $ \case
+        NoMacKeycodeFrom _ -> True
+        _ -> False
+      -> do
+        for_ e (logDebug . displayShow)
+        iokitRead b
+      | otherwise -> throwIO e
+    Just (Right k)  -> pure k


### PR DESCRIPTION
We simply ignore keys we don't handle.
Maybe we should retransmit them instead?

This
- fixes #817

@jsimonetti, could you verify this works?