### PR TITLE
Add `tap-hold-next-press` variant

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Added `boot.initrd.services.kmonad.enable` NixOS option to use KMonad in the initrd (#941).
 - Added `key-seq-delay`, a more general version of `cmp-seq-delay`, which enforces a minimum delay
   after each key event. (#908)
+- Added `tap-hold-next-press` which is like `tap-next-press` but with an additional timeout. (#971)
 
 ### Changed
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -342,8 +342,16 @@ to be the most comfortable.
   (defalias tnp (tap-next-press a sft))
   ```
 
++ `tap-hold-next-press`: like `tap-next-press` but with an
+  additional timeout. This is just like `tap-hold-next`, but with
+  `tap-next` swapped out for `tap-next-press`.
+
+  ```clojure
+  (defalias thp (tap-hold-next-press 1000 a sft))
+  ```
+
 + `tap-hold-next-release`: like `tap-next-release` but with an
-  additional timeout. This is just like `tap-next-release`, but with
+  additional timeout. This is just like `tap-hold-next`, but with
   `tap-next` swapped out for `tap-next-release`.
 
   ```clojure

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -909,13 +909,18 @@
     Pesc Pa Resc Ra -> A (because a is pressed before esc is released)
     Pesc Ta Resc    -> A (a is pressed before esc is released here as well)
 
+  It also has a hold variant named `tap-hold-next-press` (notice a trend?).
+  It works just like `tap-next-press` except that after the timeout it will
+  jump into holding-mode. The holding button for the timeout case can be swapped
+  out just like `tap-hold-next` via a `:timeout-button ...` as the last argument.
+
   These increasingly stranger buttons are, I think, coming from the stubborn
   drive of some of my more eccentric (and I mean that in the most positive way)
   users to make typing with modifiers on the home-row more comfortable.
   Especially layouts that encourage a lot of rolling motions are nicer to use
   with the `release` style buttons.
 
-  The `tap-hold-next-release` (notice a trend?) is just like `tap-next-release`,
+  The `tap-hold-next-release` is just like `tap-next-release`,
   but it comes with an additional timeout that, just like `tap-hold-next` will
   jump into holding-mode after a timeout.
 
@@ -932,6 +937,7 @@
   thn (tap-hold-next 400 x lsft)
   tnr (tap-next-release x lsft)
   tnp (tap-next-press x lsft)
+  thp (tap-hold-next-press 2000 x lsft)
   tnh (tap-hold-next-release 2000 x lsft)
 
   ;; Used it the colemak layer
@@ -943,7 +949,7 @@
   @mt  _    _    _    _    _    _    _    _    _    _    _    @rem _
   _    _    _    _    _    _    _    _    _    _    _    _    _    _
   @thn _    _    _    _    _    _    _    _    _    _    _    _
-  @xtn _    _    _    _    _    _    _    _    _    _    @xth
+  @xtn @thp _    _    _    _    _    _    _    _    _    @xth
   @tnr @tnp _              _              _    _    _    @tnh
 )
 

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -415,6 +415,8 @@ joinButton ns als =
     KTapHoldNextRelease ms t h mtb
       -> jst $ tapHoldNextRelease (fi ms) <$> go t <*> go h <*> traverse go mtb
     KTapNextPress t h  -> jst $ tapNextPress       <$> go t <*> go h
+    KTapHoldNextPress ms t h mtb
+      -> jst $ tapHoldNextPress (fi ms) <$> go t <*> go h <*> traverse go mtb
     KAroundOnly o i    -> jst $ aroundOnly         <$> go o <*> go i
     KAroundWhenAlone o i -> jst $ aroundWhenAlone  <$> go o <*> go i
     KAroundImplicit o i  -> joinButton ns als =<< fromImplArnd o i =<< view implArnd

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -281,6 +281,9 @@ keywordButtons =
                           <*> optional (keywordP "timeout-button" buttonP))
   , ("tap-next-press"
     , KTapNextPress <$> buttonP <*> buttonP)
+  , ("tap-hold-next-press"
+    , KTapHoldNextPress <$> lexeme numP <*> buttonP <*> buttonP
+                        <*> optional (keywordP "timeout-button" buttonP))
   , ("tap-next"       , KTapNext     <$> buttonP     <*> buttonP)
   , ("layer-toggle"   , KLayerToggle <$> lexeme word)
   , ("momentary-layer" , KLayerToggle <$> lexeme word)

--- a/src/KMonad/Args/Types.hs
+++ b/src/KMonad/Args/Types.hs
@@ -72,6 +72,8 @@ data DefButton
   | KTapHoldNextRelease Int DefButton DefButton (Maybe DefButton)
     -- ^ Like KTapNextRelease but with a timeout
   | KTapNextPress DefButton DefButton      -- ^ Like KTapNextRelease but also hold on presses
+  | KTapHoldNextPress Int DefButton DefButton (Maybe DefButton)
+    -- ^ Like KTapNextPress but with a timeout
   | KAroundNext DefButton                  -- ^ Surround a future button
   | KAroundNextSingle DefButton            -- ^ Surround a future button
   | KMultiTap [(Int, DefButton)] DefButton -- ^ Do things depending on tap-count


### PR DESCRIPTION
This fixes #951

### Description

The missing `tap-hold-next-press` variant.
@mistekko could you try this before I merge this?