### PR TITLE
Change default `key-seq-delay` to 1ms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 - `multi-tap` now holds when interrupted by another key while held. (#897)
 - `key-seq-delay` defaults to 1ms (#975).
+  If this slowdown in e.g. `tap-macro`s bothers you, you may want to set it to 0.
+  If you used `cmp-seq-delay`, you probably no longer have to,
+  as `key-seq-delay` effectivly already implies a `cmp-seq-delay`.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### Changed
 
 - `multi-tap` now holds when interrupted by another key while held. (#897)
+- `key-seq-delay` defaults to 1ms (#975).
 
 ### Fixed
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -16,6 +16,7 @@
     - [Q: How to use the special features printed on Apple function keys?](#q-how-to-use-the-special-features-printed-on-apple-function-keys)
 - [General](#general)
     - [Q: Why can't I remap certain (non US) buttons?](#q-why-cant-i-remap-certain-non-us-buttons)
+    - [Q: Why don't shifted symbols work (sometimes)?](#q-why-dont-shifted-symbols-work-sometimes)
     - [Q: What does `Ta`, `Pa` and `Ra` stand for?](#q-what-does-ta-pa-and-ra-stand-for)
     - [Q: Why doesn't the 'Print' keycode work for my print screen button?](#q-why-doesnt-the-print-keycode-work-for-my-print-screen-button)
     - [Q: Why can't I remap the Fn key on my laptop?](#q-why-cant-i-remap-the-fn-key-on-my-laptop)
@@ -218,6 +219,14 @@ you would specify the letter that would be there in qwerty (`[`).
 This is of course also true for buttons which are in a different place.
 On the german layout the `+` is reached without shift, while on US qwerty it's
 on `S-=`. This means it's also not a valid keycode to specify in your `defsrc`.
+
+### Q: Why don't shifted symbols work (sometimes)?
+
+A: In some environments, applications cannot process key events that are too fast.
+If you notice this with `tap-macro` or shifted symbols (like `A`) you
+may want to increase the value for `key-seq-delay` in `defcfg` to
+something like `5`ms.
+Here is the [original bug report](https://github.com/kmonad/kmonad/issues/820).
 
 ### Q: What does `Ta`, `Pa` and `Ra` stand for?
 

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -86,7 +86,9 @@ The following are all global config options that one can set in the
 + `cmp-seq-delay` (natural number, defaults to `0`): delay between each pressed key in a
   compose-key sequence.
 
-+ `key-seq-delay` (natural number, defaults to `1`): delay between each outputted key event.
++ `key-seq-delay` (natural number, defaults to `1`): delay after each outputted key event.
+  Since it's more general than `cmp-seq-delay`, it implies a minimum `cmp-seq-delay`.
+  Be careful with this option: larger values are easily noticeable in `tap-macro`s.
 
 + `implicit-around` (around variant, defaults to `around`):
   Specifies the variant of `around` to use in implicit around constructs

--- a/doc/quick-reference.md
+++ b/doc/quick-reference.md
@@ -86,7 +86,7 @@ The following are all global config options that one can set in the
 + `cmp-seq-delay` (natural number, defaults to `0`): delay between each pressed key in a
   compose-key sequence.
 
-+ `key-seq-delay` (natural number, defaults to `5`): delay between each outputted key event.
++ `key-seq-delay` (natural number, defaults to `1`): delay between each outputted key event.
 
 + `implicit-around` (around variant, defaults to `around`):
   Specifies the variant of `around` to use in implicit around constructs

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -103,17 +103,20 @@
 
   - `cmp-seq-delay': NUMBER, defaults to `0` (in milliseconds)
 
-    This sets a delay between each pressed key in a compose-key sequence.  Some
-    environments may have troubles recognizing the key sequence if it's pressed
-    too rapidly; if you experience any problems in this direction, you can try
-    setting this value to `5' or `10' and see if that helps.
+    This sets a delay between each pressed key in a compose-key sequence.
+    This is mostly not needed, as `key-seq-delay` already implies a small delay.
+    If you still have issues, with some environments failing to recognize
+    the key sequence due to its speed, you may want to increase this value
+    to `5` or `10` and see if that helps. Alternatively, take a look at
+    the `key-seq-delay` option for a more general approach.
 
   - `key-seq-delay': NUMBER, defaults to `1` (in milliseconds)
 
-    This sets a delay between each outputted key event globally. Similarly to
-    `cmp-seq-delay` this may solve troubles caused by keys being ignored when
-    pressed to rapidly. You probably shouldn't specify both `cmp-seq-delay` and
-    `key-seq-delay`.
+    This sets a delay after each outputted key event globally. Similarly to
+    `cmp-seq-delay` this may fix problems with keys being ignored when pressed
+    too rapidly. You probably won't need to specify both `cmp-seq-delay` and
+    `key-seq-delay`. Be careful with this option, as larger values are easily
+    noticeable in `tap-macro`s.
 
   Secondly, let's go over how to specify the `input` and `output` fields of a
   `defcfg` block. This differs between OSes, and so do the capabilities of

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -108,7 +108,7 @@
     too rapidly; if you experience any problems in this direction, you can try
     setting this value to `5' or `10' and see if that helps.
 
-  - `key-seq-delay': NUMBER, defaults to `5` (in milliseconds)
+  - `key-seq-delay': NUMBER, defaults to `1` (in milliseconds)
 
     This sets a delay between each outputted key event globally. Similarly to
     `cmp-seq-delay` this may solve troubles caused by keys being ignored when

--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -616,6 +616,14 @@
 
     (tap-macro K P5 M P5 o P5 n P5 a P5 d)
 
+  Alternatively, you could use the more general approach and change the
+  value for `key-seq-delay` in `defcfg`. Also notice that the values
+  don't add up: due to the difference in where the delay is applied, the
+  maximum takes effect. (`key-seq-delay` works on outputted events, and
+  `:delay` is while handling the button) If you use really long
+  `tap-macro`s (like storing your email), you may experiment with a
+  delay of `0` to have a more "paste-like" experience.
+
   The `tap-macro-release` is like `tap-macro`, except that it
   waits to press the last button when the `tap-macro-release`
   gets released.  It might be useful when combined with a

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -62,7 +62,7 @@ let
           type = lib.types.ints.unsigned;
           default = 1;
           example = 0;
-          description = "The delay (in milliseconds) between each key outputted event.";
+          description = "The delay (in milliseconds) after each key outputted event.";
         };
 
         fallthrough = lib.mkEnableOption "reemitting unhandled key events";

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -60,7 +60,7 @@ let
 
         keySeqDelay = lib.mkOption {
           type = lib.types.ints.unsigned;
-          default = 5;
+          default = 1;
           example = 0;
           description = "The delay (in milliseconds) between each key outputted event.";
         };

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -277,7 +277,7 @@ getKeySeqDelay = do
   case onlyOne . extract _SKeySeqDelay $ cfg of
     Right 0        -> pure Nothing
     Right b        -> pure (Just b)
-    Left None      -> pure (Just 5)
+    Left None      -> pure (Just 1)
     Left Duplicate -> throwError $ DuplicateSetting "key-seq-delay"
 
 #ifdef linux_HOST_OS


### PR DESCRIPTION
This should fix most problems users may have, while still being not to
noticeable in `tap-macro`s. We may also want to consider changing from
milliseconds to microseconds or allowing fractional values for
`key-seq-delay` and `cmp-seq-delay`.

This effectivly partially reverts https://github.com/kmonad/kmonad/commit/c2ce56137a867b530bfe7fb3ccc6a0ea47b7a9c4:
> Set default for `key-seq-delay` to 5ms

(Sorry, my bad. I should have allowed for discussions via a PR.)