### PR TITLE
Fixed `multi-tap` holding while released and cancel the sequence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed `tapMacro` and `tapMacroRelease` behaviour which was slightly broken in #873 (#906)
 - Fixed keycode translation problem on windows (#894)
 - Fixed keyrepeat not working in tty on linux (#913)
-- Fixed `multi-tap` not holding (#958)
+- Fixed `multi-tap` not holding (#958, #976)
 - Fixed `multi-tap` cancelling on release of other keys (#974)
 
 ## 0.4.3 – 2024-09-11


### PR DESCRIPTION
We also cancel `multi-tap` on release but only while released. This should fix `multi-tap` in a layer keeping it's definition through layer-switch (see #954 for an equivalent issue for `stepped`).

Also note, this does not revert #958 or #974.
Effectively they overshot the goal slightly.
It also doesn't reintroduce the issues #958 and #974 where designed to fix.

Hey @MaxG87, since you opened those issues originally and use `multi-tap` more heavily, could you test this PR and whether it matches expectations of what `multi-tap` should do.
