### PR TITLE
Minor cleanup

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -21,7 +21,8 @@ jobs:
           - lts-20               # GHC 9.2
           - lts-21               # GHC 9.4
           - lts-22               # GHC 9.6
-          - nightly-2024-07-05   # GHC 9.8
+          - lts-23               # GHC 9.8
+          - nightly-2025-03-06   # GHC 9.10
 
     steps:
       - name: Clone project

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,17 +6,26 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Nix Flake CI - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
     steps:
 
-    - name: Clone project
-      uses: actions/checkout@v4
+      - name: Clone project
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - name: Install Nix
-      uses: cachix/install-nix-action@v30
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
 
-    - name: Build flake
-      run: nix build --print-build-logs nix
+      - name: Build flake
+        run: nix build --print-build-logs 'git+file:///${{ github.workspace }}?dir=nix&submodules=1'
 
-    - name: Check flake
-      run: nix flake check 'git+file:.?dir=nix'
+      - name: Check flake
+        run: nix flake check 'git+file:///${{ github.workspace }}?dir=nix&submodules=1'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,10 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v27
-      with:
-        # NixCPP url-parsing is currently broken.
-        install_url: https://releases.nixos.org/nix/nix-2.24.12/install
+      uses: cachix/install-nix-action@v30
 
     - name: Build flake
       run: nix build --print-build-logs nix

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -19,8 +19,9 @@
       supportedCompilers = [
         "ghc928"
         "ghc948"
-        "ghc965"
-        "ghc983"
+        "ghc966"
+        "ghc984"
+        "ghc9101"
       ];
 
       # Function to generate a set based on supported systems:

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -64,10 +64,6 @@
             pkgs.darwin.IOKit
           ]);
       } // (pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
-        configureFlags = orig.configureFlags ++ [
-          "--extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/src/Client/vendor/include"
-          "--extra-include-dirs=c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include/pqrs/karabiner/driverkit"
-        ];
         statSubmodulePhase = ''
           stat c_src/mac/Karabiner-DriverKit-VirtualHIDDevice/include || (
             echo "Karabiner submodule not found. This flake needs to be built with submodules on darwin. See the KMonad docs for more information." 1>&2

--- a/src/KMonad/Gesture.hs
+++ b/src/KMonad/Gesture.hs
@@ -11,7 +11,6 @@ import Control.Monad.Except
 import Control.Monad.State
 import Data.Char
 
-import RIO.List.Partial (head)
 import RIO.Seq (Seq(..))
 
 import qualified RIO.List as L
@@ -67,8 +66,9 @@ around x g@(Gesture seq)
 fromList :: Ord a => [Toggle a] -> Either (GestureError a) (Gesture a)
 fromList as = case (`runState` S.empty) . runExceptT . foldM f Q.empty $ as of
   (Left e, _) -> Left e
-  (Right g, s) | S.null s -> Right $ Gesture g
-               | otherwise -> Left $ OnWithoutOff (head . S.elems $ s)
+  (Right g, s) -> case S.lookupMin s of
+    Just toggle -> Left $ OnWithoutOff toggle
+    Nothing     -> Right $ Gesture g
   where
     f s x = do
       pressed <- get


### PR DESCRIPTION
Some fixes. Including:
- Removed arguments in `flake.nix` which are now in `kmonad.cabal` (#959)
  This would have also broken #937. Therefore we also add a CI run of `nix` on macos.
- Added GHC 9.10 in CI and mark as supported in flake
- Fixed the warning about partial function in CI