### PR TITLE
Set keyboard string for unknown keyboards on macos

### DIFF
--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -88,7 +88,7 @@ void open_matching_devices(char *product, io_iterator_t iter) {
         CFStringRef cfcurr = (CFStringRef)IORegistryEntryCreateCFProperty(curr, CFSTR(kIOHIDProductKey), kCFAllocatorDefault, kIOHIDOptionsTypeNone);
         if(cfcurr == NULL) {
             print_iokit_error("IORegistryEntryCreateCFProperty");
-            continue;
+            cfcurr = CFStringCreateWithCString (NULL, "Unknown External Keyboard", kCFStringEncodingUTF8);
         }
 
         // any device named "Karabiner ..." should be ignored

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Added `key-seq-delay`, a more general version of `cmp-seq-delay`, which enforces a minimum delay
   after each key event. (#908)
 - Added `tap-hold-next-press` which is like `tap-next-press` but with an additional timeout. (#971)
+- Set unknown keyboard names to "Unknown External Keyboard" on Macos. (#980)
 
 ### Changed
 


### PR DESCRIPTION
### Description

When Macos cannot detect a keyboards' name (usually due to bad firmware), it sets the name to "Unknown External Keyboard". By mimicing this behavior in Kmonad, the keyboard can still be used. It will also allow usage of the input name in your config using `input (iokit-name "Unknown External Keyboard")`

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/kmonad/kmonad/blob/master/CONTRIBUTING.md)
- [X] I've also appended my changes to the `CHANGELOG.md` if applicable
