### PR TITLE
Slightly improved error messages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,10 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### Added
 
 ### Changed
+
 - Update Karabiner-DriverKit to 5.0.0 (#937)
   You will now need to [start the server yourself](doc/installation.md#starting-the-dext-daemon).
 
 ### Fixed
+
+- Fixed excessive backtracking in the parser leading to unreadable errors (#985)
 
 ## 0.4.4 – 2025-04-11
 

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -71,6 +71,7 @@ library
       RankNTypes
       TemplateHaskell
       TupleSections
+      TypeApplications
       TypeFamilies
 
   autogen-modules:

--- a/src/KMonad/Args/Cmd.hs
+++ b/src/KMonad/Args/Cmd.hs
@@ -17,12 +17,12 @@ module KMonad.Args.Cmd
 where
 
 import KMonad.Prelude hiding (try)
-import KMonad.Args.Parser (itokens, keywordButtons, noKeywordButtons, otokens, symbol, numP, implArndButtons)
 import KMonad.Args.TH (gitHash)
 import KMonad.Args.Types (DefSetting(..))
 import KMonad.Util
 import Paths_kmonad (version)
 
+import qualified KMonad.Args.Parser as P
 import qualified KMonad.Parsing as M  -- [M]egaparsec functionality
 
 import Data.Version (showVersion)
@@ -137,8 +137,7 @@ fallThrghP = SFallThrough <$> switch
 
 -- | Key to use for compose-key sequences
 cmpSeqP :: Parser (Maybe DefSetting)
-cmpSeqP = optional $ SCmpSeq <$> option
-  (tokenParser keywordButtons <|> megaReadM (M.choice noKeywordButtons))
+cmpSeqP = optional $ SCmpSeq <$> option (megaReadM $ P.buttonP' True)
   (  long "cmp-seq"
   <> short 's'
   <> metavar "BUTTON"
@@ -147,7 +146,7 @@ cmpSeqP = optional $ SCmpSeq <$> option
 
 -- | Specify compose sequence key delays.
 cmpSeqDelayP :: Parser (Maybe DefSetting)
-cmpSeqDelayP = optional $ SCmpSeqDelay <$> option (fromIntegral <$> megaReadM numP)
+cmpSeqDelayP = optional $ SCmpSeqDelay <$> option (megaReadM P.numP)
   (  long  "cmp-seq-delay"
   <> metavar "TIME"
   <> help  "How many ms to wait between each key of a compose sequence"
@@ -155,7 +154,7 @@ cmpSeqDelayP = optional $ SCmpSeqDelay <$> option (fromIntegral <$> megaReadM nu
 
 -- | Specify key event output delays.
 keySeqDelayP :: Parser (Maybe DefSetting)
-keySeqDelayP = optional $ SKeySeqDelay <$> option (fromIntegral <$> megaReadM numP)
+keySeqDelayP = optional $ SKeySeqDelay <$> option (megaReadM P.numP)
   (  long  "key-seq-delay"
   <> metavar "TIME"
   <> help  "How many ms to wait between each key event outputted"
@@ -163,8 +162,7 @@ keySeqDelayP = optional $ SKeySeqDelay <$> option (fromIntegral <$> megaReadM nu
 
 -- | How to handle implicit `around`s
 implArndP :: Parser (Maybe DefSetting)
-implArndP = optional $ SImplArnd <$> option
-  (maybeReader $ \x -> implArndButtons ^? each . filtered ((x ==) . unpack . view _1) . _2)
+implArndP = optional $ SImplArnd <$> option (megaReadM P.implArndP)
   (  long "implicit-around"
   <> long "ia"
   <> metavar "AROUND"
@@ -173,7 +171,7 @@ implArndP = optional $ SImplArnd <$> option
 
 -- | Where to emit the output
 oTokenP :: Parser (Maybe DefSetting)
-oTokenP = optional $ SOToken <$> option (tokenParser otokens)
+oTokenP = optional $ SOToken <$> option (mkTokenP P.otokens)
   (  long "output"
   <> short 'o'
   <> metavar "OTOKEN"
@@ -182,7 +180,7 @@ oTokenP = optional $ SOToken <$> option (tokenParser otokens)
 
 -- | How to capture the keyboard input
 iTokenP :: Parser (Maybe DefSetting)
-iTokenP = optional $ SIToken <$> option (tokenParser itokens)
+iTokenP = optional $ SIToken <$> option (mkTokenP P.itokens)
   (  long "input"
   <> short 'i'
   <> metavar "ITOKEN"
@@ -191,7 +189,7 @@ iTokenP = optional $ SIToken <$> option (tokenParser itokens)
 
 -- | Parse a flag that disables auto-releasing the release of enter
 startDelayP :: Parser Milliseconds
-startDelayP = option (fromIntegral <$> megaReadM numP)
+startDelayP = option (fromIntegral <$> megaReadM P.numP)
   (  long  "start-delay"
   <> short 'w'
   <> value 300
@@ -201,8 +199,8 @@ startDelayP = option (fromIntegral <$> megaReadM numP)
 
 -- | Transform a bunch of tokens of the form @(Keyword, Parser)@ into an
 -- optparse-applicative parser
-tokenParser :: [(Text, M.Parser a)] -> ReadM a
-tokenParser = megaReadM . M.choice . map (M.try . uncurry ((*>) . symbol))
+mkTokenP :: [(Text, M.Parser a)] -> ReadM a
+mkTokenP = megaReadM . P.mkTokenP' True
 
 -- | Megaparsec <--> optparse-applicative interface
 megaReadM :: M.Parser a -> ReadM a

--- a/src/KMonad/Args/Parser.hs
+++ b/src/KMonad/Args/Parser.hs
@@ -22,13 +22,18 @@ module KMonad.Args.Parser
 
   -- * Building Parsers
   , symbol
+  , keyword
+  , sexpr
   , numP
+  , mkTokenP'
 
   -- * Parsers for Tokens and Buttons
   , otokens
   , itokens
   , buttonP
+  , buttonP'
   , implArndButtons
+  , implArndP
   , keywordButtons
   , noKeywordButtons
   )
@@ -44,13 +49,12 @@ import KMonad.Keyboard.ComposeSeq
 
 
 import Data.Char
-import RIO.List (sortBy, find)
+import RIO.List (find)
 
 
 import qualified KMonad.Util.MultiMap as Q
 import qualified RIO.Text as T
 import qualified Text.Megaparsec.Char.Lexer as L
-
 
 --------------------------------------------------------------------------------
 -- $run
@@ -79,57 +83,60 @@ lexeme = L.lexeme sc
 symbol :: Text -> Parser ()
 symbol = void . L.symbol sc
 
--- | List of all characters that /end/ a word or sequence
-terminators :: String
-terminators = ")\""
+-- | A predicate to check if a characters /ends/ a word or sequence
+isDelimiter :: Char -> Bool
+isDelimiter c = elem @[] c "()\"" || isSpace c
 
-terminatorP :: Parser Char
-terminatorP = satisfy (`elem` terminators)
+terminatorP :: Parser ()
+terminatorP = void (satisfy isDelimiter) <|> eof <?> "end of token / delimiter"
 
--- | Consume all chars until a space is encounterd
+-- | Consume all chars until a delimiter is encounterd
 word :: Parser Text
-word = T.pack <$> some (satisfy wordChar)
-  where wordChar c = not (isSpace c || c `elem` terminators)
+word = lexeme . takeWhile1P Nothing $ not . isDelimiter
 
--- | Run the parser IFF it is followed by a space, eof, or reserved char
+-- | Run the parser IFF it is terminated
 terminated :: Parser a -> Parser a
-terminated p = try $ p <* lookAhead (void spaceChar <|> eof <|> void terminatorP)
+terminated p = try . lexeme $ p <* lookAhead terminatorP
 
--- | Run the parser IFF it is not followed by a space or eof.
-prefix :: Parser a -> Parser a
-prefix p = try $ p <* notFollowedBy (void spaceChar <|> eof)
+-- | Keywords are terminated symbols
+keyword :: Text -> Parser ()
+keyword = terminated . void . string -- `string` intead of `symbol`, since `terminated` already does `lexeme`
+
+keyword' :: Text -> a -> Parser a
+keyword' k x = keyword k $> x
+
+-- | Run a parser designed to parse an inner S-expression.
+sexpr :: Text -> Parser a -> Parser a
+sexpr s p = keyword s *> p
 
 -- | Create a parser that matches symbols to values and only consumes on match.
 fromNamed :: [(Text, a)] -> Parser a
-fromNamed = choice . map mkOne . srt
-  where
-    -- | Sort descending by length of key and then alphabetically
-    srt :: [(Text, b)] -> [(Text, b)]
-    srt = sortBy . flip on fst $ \a b ->
-      case compare (T.length b) (T.length a) of
-        EQ -> compare a b
-        x  -> x
-
-    -- | Make a parser that matches a terminated symbol or fails
-    mkOne (s, x) = terminated (string s) $> x
+fromNamed = choice . map (uncurry keyword')
 
 -- | Run a parser between 2 sets of parentheses
 paren :: Parser a -> Parser a
 paren = between (symbol "(") (symbol ")")
 
--- | Run a parser between 2 sets of parentheses starting with a symbol
-statement :: Text -> Parser a -> Parser a
-statement s = paren . (symbol s *>)
-
 -- | Run a parser that parser a bool value
-bool :: Parser Bool
-bool = (symbol "true"  $> True)
-   <|> (symbol "false" $> False)
+boolP :: Parser Bool
+boolP = keyword' "true" True <|> keyword' "false" False
 
--- | Parse a LISP-like keyword of the form @:keyword value@
-keywordP :: Text -> Parser p -> Parser p
-keywordP kw p = symbol (":" <> kw) *> lexeme p
-  <?> "Keyword " <> ":" <> T.unpack kw
+-- | Parse an option argument of the form @:keyword value@
+optargP :: Text -> Parser p -> Parser p
+optargP a p = keyword (":" <> a) *> p
+  <?> "Keyword " <> ":" <> unpack a
+
+optarg'P :: Text -> Parser p -> Parser (Maybe p)
+optarg'P a = optional . optargP a
+
+-- | Parse based on a liste of sexpressions
+mkTokenP :: [(Text, Parser a)] -> Parser a
+mkTokenP = mkTokenP' False
+
+mkTokenP' :: Bool -> [(Text, Parser a)] -> Parser a
+mkTokenP' toplevel tkns = paren' . choice $ uncurry sexpr <$> tkns
+ where
+  paren' = if toplevel then id else paren
 
 --------------------------------------------------------------------------------
 -- $elem
@@ -142,18 +149,15 @@ keycodeP = fromNamed (Q.reverse keyNames ^.. Q.itemed) <?> "keycode"
 
 -- | Parse an integer
 numP :: Parser Int
-numP = L.decimal
+numP = terminated L.decimal
 
 -- | Parse text with escaped characters between double quotes.
 textP :: Parser Text
-textP = do
-  _ <- char '\"'
-  s <- manyTill L.charLiteral (char '\"')
-  pure . T.pack $ s
+textP = lexeme $ char '"' >> pack <$> manyTill L.charLiteral (char '"')
 
 -- | Parse a variable reference
 derefP :: Parser Text
-derefP = prefix (char '@') *> word
+derefP = char '@' *> word
 
 --------------------------------------------------------------------------------
 -- $cmb
@@ -166,15 +170,15 @@ configP = sc *> exprsP <* eof
 
 -- | Parse 0 or more KExpr's
 exprsP :: Parser [KExpr]
-exprsP = lexeme . many $ lexeme exprP
+exprsP = many exprP
 
 -- | Parse 1 KExpr
 exprP :: Parser KExpr
 exprP = paren . choice $
-  [ try (symbol "defcfg")   *> (KDefCfg   <$> defcfgP)
-  , try (symbol "defsrc")   *> (KDefSrc   <$> defsrcP)
-  , try (symbol "deflayer") *> (KDefLayer <$> deflayerP)
-  , try (symbol "defalias") *> (KDefAlias <$> defaliasP)
+  [ sexpr "defcfg"    $ KDefCfg   <$> defcfgP
+  , sexpr "defsrc"    $ KDefSrc   <$> defsrcP
+  , sexpr "deflayer"  $ KDefLayer <$> deflayerP
+  , sexpr "defalias"  $ KDefAlias <$> defaliasP
   ]
 
 --------------------------------------------------------------------------------
@@ -182,10 +186,12 @@ exprP = paren . choice $
 --
 -- All the various ways to refer to buttons
 
+shifted :: Keycode -> DefButton
+shifted = KAroundImplicit (KEmit KeyLeftShift) . KEmit
+
 -- | Different ways to refer to shifted versions of keycodes
 shiftedNames :: [(Text, DefButton)]
-shiftedNames = let f = second $ \kc -> KAroundImplicit (KEmit KeyLeftShift) (KEmit kc) in
-                 map f $ cps <> num <> oth <> lng
+shiftedNames = second shifted <$> cps <> num <> oth <> lng
   where
     cps = zip (map T.singleton ['A'..'Z'])
           [ KeyA, KeyB, KeyC, KeyD, KeyE, KeyF, KeyG, KeyH, KeyI, KeyJ, KeyK, KeyL, KeyM,
@@ -202,15 +208,12 @@ shiftedNames = let f = second $ \kc -> KAroundImplicit (KEmit KeyLeftShift) (KEm
 buttonNames :: [(Text, DefButton)]
 buttonNames = shiftedNames <> escp <> util
   where
-    emitS c = KAroundImplicit (KEmit KeyLeftShift) (KEmit c)
     -- Escaped versions for reserved characters
-    escp = [ ("\\(", emitS Key9), ("\\)", emitS Key0)
-           , ("\\_", emitS KeyMinus), ("\\\\", KEmit KeyBackslash)]
+    escp = [ ("\\(", shifted Key9), ("\\)", shifted Key0)
+           , ("\\_", shifted KeyMinus), ("\\\\", KEmit KeyBackslash)]
     -- Extra names for useful buttons
     util = [ ("_", KTrans), ("XX", KBlock)
-           , ("lprn", emitS Key9), ("rprn", emitS Key0)]
-
-
+           , ("lprn", shifted Key9), ("rprn", shifted Key0)]
 
 -- | Parse "X-b" style modded-sequences
 moddedP :: Parser DefButton
@@ -219,7 +222,7 @@ moddedP = KAroundImplicit <$> prfx <*> buttonP
                , ("A-", KeyLeftAlt),   ("M-", KeyLeftMeta)
                , ("RS-", KeyRightShift), ("RC-", KeyRightCtrl)
                , ("RA-", KeyRightAlt),   ("RM-", KeyRightMeta)]
-        prfx = choice $ map (\(t, p) -> prefix (string t) $> KEmit p) mods
+        prfx = choice $ map (\(t, p) -> try $ string t $> KEmit p) mods
 
 -- | Parse Pxxx as pauses (useful in macros)
 pauseP :: Parser DefButton
@@ -228,12 +231,13 @@ pauseP = KPause . fromIntegral <$> (char 'P' *> numP)
 -- | #()-syntax tap-macro
 rmTapMacroP :: Parser DefButton
 rmTapMacroP =
-  char '#' *> paren (KTapMacro <$> some buttonP
-                               <*> optional (keywordP "delay" numP))
+  try (symbol "#(")
+    >> KTapMacro <$> some buttonP <*> optarg'P "delay" numP
+    <* symbol ")"
 
 -- | Compose-key sequence
 composeSeqP :: Parser [DefButton]
-composeSeqP = do
+composeSeqP = terminated $ do
   -- Lookup 1 character in the compose-seq list
   c <- anySingle <?> "special character"
   s <- case find (\(_, c', _) -> c' == c) ssComposed of
@@ -248,8 +252,8 @@ composeSeqP = do
 
 -- | Parse a dead-key sequence as a `+` followed by some symbol
 deadkeySeqP :: Parser [DefButton]
-deadkeySeqP = do
-  _ <- prefix (char '+')
+deadkeySeqP = terminated $ do
+  _ <- char '+'
   c <- satisfy (`elem` ("~'^`\"," :: String))
   case runParser buttonP "" (T.singleton c) of
     Left  _ -> fail "Could not parse deadkey sequence"
@@ -257,61 +261,56 @@ deadkeySeqP = do
 
 -- | Parse any button
 buttonP :: Parser DefButton
-buttonP = (lexeme . choice . map try $
-  map (uncurry statement) keywordButtons ++ noKeywordButtons
-  ) <?> "button"
+buttonP = buttonP' False
+
+buttonP' :: Bool -> Parser DefButton
+buttonP' toplevel = mkTokenP' toplevel keywordButtons <|> choice noKeywordButtons <?> "button"
 
 -- | Parsers for buttons that have a keyword at the start; the format is
 -- @(keyword, how to parse the token)@
 keywordButtons :: [(Text, Parser DefButton)]
 keywordButtons =
-  [ ("around-implicit", KAroundImplicit <$> buttonP <*> buttonP)
-  , ("press-only"     , KPressOnly   <$> keycodeP)
-  , ("release-only"   , KReleaseOnly <$> keycodeP)
-  , ("multi-tap"      , KMultiTap    <$> timed       <*> buttonP)
-  , ("stepped"        , KStepped     <$> some buttonP)
-  , ("tap-hold"       , KTapHold     <$> lexeme numP <*> buttonP <*> buttonP)
-  , ("tap-hold-next"
-    , KTapHoldNext <$> lexeme numP <*> buttonP <*> buttonP
-                   <*> optional (keywordP "timeout-button" buttonP))
-  , ("tap-next-release"
-    , KTapNextRelease <$> buttonP <*> buttonP)
-  , ("tap-hold-next-release"
-    , KTapHoldNextRelease <$> lexeme numP <*> buttonP <*> buttonP
-                          <*> optional (keywordP "timeout-button" buttonP))
-  , ("tap-next-press"
-    , KTapNextPress <$> buttonP <*> buttonP)
-  , ("tap-hold-next-press"
-    , KTapHoldNextPress <$> lexeme numP <*> buttonP <*> buttonP
-                        <*> optional (keywordP "timeout-button" buttonP))
-  , ("tap-next"       , KTapNext     <$> buttonP     <*> buttonP)
-  , ("layer-toggle"   , KLayerToggle <$> lexeme word)
-  , ("momentary-layer" , KLayerToggle <$> lexeme word)
-  , ("layer-switch"    , KLayerSwitch <$> lexeme word)
-  , ("permanent-layer" , KLayerSwitch <$> lexeme word)
-  , ("layer-add"      , KLayerAdd    <$> lexeme word)
-  , ("layer-rem"      , KLayerRem    <$> lexeme word)
-  , ("layer-delay"    , KLayerDelay  <$> lexeme numP <*> lexeme word)
-  , ("layer-next"     , KLayerNext   <$> lexeme word)
-  , ("around-next"    , KAroundNext  <$> buttonP)
-  , ("around-next-single", KAroundNextSingle <$> buttonP)
-  , ("before-after-next", KBeforeAfterNext <$> buttonP <*> buttonP)
-  , ("around-next-timeout", KAroundNextTimeout <$> lexeme numP <*> buttonP <*> buttonP)
-  , ("tap-macro"
-    , KTapMacro <$> lexeme (some buttonP) <*> optional (keywordP "delay" numP))
-  , ("tap-macro-release"
-    , KTapMacroRelease <$> lexeme (some buttonP) <*> optional (keywordP "delay" numP))
-  , ("cmd-button"     , KCommand     <$> lexeme textP <*> optional (lexeme textP))
-  , ("pause"          , KPause . fromIntegral <$> lexeme numP)
-  , ("sticky-key"     , KStickyKey   <$> lexeme numP <*> buttonP)
+  [ (,) "around-implicit"          $ KAroundImplicit        <$> buttonP  <*> buttonP
+  , (,) "press-only"               $ KPressOnly             <$> keycodeP
+  , (,) "release-only"             $ KReleaseOnly           <$> keycodeP
+  , (,) "multi-tap"                $ KMultiTap              <$> timed    <*> buttonP
+  , (,) "stepped"                  $ KStepped               <$> buttonsP
+  , (,) "tap-hold"                 $ KTapHold               <$> numP     <*> buttonP <*> buttonP
+  , (,) "tap-hold-next"            $ KTapHoldNext           <$> numP     <*> buttonP <*> buttonP <*> timeoutP
+  , (,) "tap-next-release"         $ KTapNextRelease        <$> buttonP  <*> buttonP
+  , (,) "tap-hold-next-release"    $ KTapHoldNextRelease    <$> numP     <*> buttonP <*> buttonP <*> timeoutP
+  , (,) "tap-next-press"           $ KTapNextPress          <$> buttonP  <*> buttonP
+  , (,) "tap-hold-next-press"      $ KTapHoldNextPress      <$> numP     <*> buttonP <*> buttonP <*> timeoutP
+  , (,) "tap-next"                 $ KTapNext               <$> buttonP  <*> buttonP
+  , (,) "layer-toggle"             $ KLayerToggle           <$> word
+  , (,) "momentary-layer"          $ KLayerToggle           <$> word
+  , (,) "layer-switch"             $ KLayerSwitch           <$> word
+  , (,) "permanent-layer"          $ KLayerSwitch           <$> word
+  , (,) "layer-add"                $ KLayerAdd              <$> word
+  , (,) "layer-rem"                $ KLayerRem              <$> word
+  , (,) "layer-delay"              $ KLayerDelay            <$> numP     <*> word
+  , (,) "layer-next"               $ KLayerNext             <$> word
+  , (,) "around-next"              $ KAroundNext            <$> buttonP
+  , (,) "around-next-single"       $ KAroundNextSingle      <$> buttonP
+  , (,) "before-after-next"        $ KBeforeAfterNext       <$> buttonP  <*> buttonP
+  , (,) "around-next-timeout"      $ KAroundNextTimeout     <$> numP     <*> buttonP <*> buttonP
+  , (,) "tap-macro"                $ KTapMacro              <$> buttonsP <*> delayP
+  , (,) "tap-macro-release"        $ KTapMacroRelease       <$> buttonsP <*> delayP
+  , (,) "cmd-button"               $ KCommand               <$> textP    <*> optional textP
+  , (,) "pause"                    $ kPause                 <$> numP
+  , (,) "sticky-key"               $ KStickyKey             <$> numP     <*> buttonP
   ]
   ++ map (\(nm,_,btn) -> (nm, btn <$> buttonP <*> buttonP)) implArndButtons
  where
   timed :: Parser [(Int, DefButton)]
-  timed = many ((,) <$> lexeme numP <*> lexeme buttonP)
+  timed = many ((,) <$> numP <*> buttonP)
+  kPause = KPause . fromIntegral
+  buttonsP = some buttonP
+  timeoutP = optarg'P "timeout-button" buttonP
+  delayP   = optarg'P "delay" numP
 
 implArndButtons :: [(Text, ImplArnd, DefButton -> DefButton -> DefButton)]
-implArndButtons = sortBy (flip compare `on` (T.length . view _1)) -- Prevents early return due to `around`
+implArndButtons =
   [ ("around"           , IAAround         , KAround)
   , ("around-only"      , IAAroundOnly     , KAroundOnly)
   , ("around-when-alone", IAAroundWhenAlone, KAroundWhenAlone)
@@ -321,11 +320,11 @@ implArndButtons = sortBy (flip compare `on` (T.length . view _1)) -- Prevents ea
 noKeywordButtons :: [Parser DefButton]
 noKeywordButtons =
   [ KComposeSeq <$> deadkeySeqP
+  , rmTapMacroP
+  , fromNamed buttonNames
   , KRef  <$> derefP
-  , lexeme $ fromNamed buttonNames
-  , try moddedP
-  , lexeme $ try rmTapMacroP
-  , lexeme $ try pauseP
+  , moddedP
+  , pauseP
   , KEmit <$> keycodeP
   , KComposeSeq <$> composeSeqP
   ]
@@ -335,56 +334,58 @@ noKeywordButtons =
 
 -- | Parse an input token
 itokenP :: Parser IToken
-itokenP = choice $ map (try . uncurry statement) itokens
+itokenP = mkTokenP itokens
 
 -- | Input tokens to parse; the format is @(keyword, how to parse the token)@
 itokens :: [(Text, Parser IToken)]
 itokens =
-  [ ("device-file"   , KDeviceSource <$> (T.unpack <$> lexeme textP))
+  [ ("device-file"   , KDeviceSource . unpack <$> textP)
   , ("low-level-hook", pure KLowLevelHookSource)
-  , ("iokit-name"    , KIOKitSource <$> optional (lexeme textP))]
+  , ("iokit-name"    , KIOKitSource <$> optional textP)
+  ]
 
 -- | Parse an output token
 otokenP :: Parser OToken
-otokenP = choice $ map (try . uncurry statement) otokens
+otokenP = mkTokenP otokens
 
 -- | Output tokens to parse; the format is @(keyword, how to parse the token)@
 otokens :: [(Text, Parser OToken)]
 otokens =
-  [ ("uinput-sink"    , KUinputSink <$> lexeme textP <*> optional (lexeme textP))
-  , ("send-event-sink", KSendEventSink <$> optional ((,) <$> lexeme numP <*> lexeme numP))
-  , ("kext"           , pure KKextSink)]
+  [ ("uinput-sink"    , KUinputSink <$> textP <*> optional textP)
+  , ("send-event-sink", KSendEventSink <$> optional ((,) <$> numP <*> numP))
+  , ("kext"           , pure KKextSink)
+  ]
 
 -- | Parse an impl arnd token
 implArndP :: Parser ImplArnd
-implArndP = lexeme . choice $
-  try (IADisabled <$ symbol "disabled")
-  : map (\(s, v, _) -> try $ v <$ symbol s) implArndButtons
+implArndP = choice $
+  keyword' "disabled" IADisabled
+  : map (\(s, v, _) -> keyword' s v) implArndButtons
 
 -- | Parse the DefCfg token
 defcfgP :: Parser DefSettings
-defcfgP = some (lexeme settingP)
+defcfgP = some settingP
 
 -- | All possible configuration options that can be passed in the defcfg block
 settingP :: Parser DefSetting
-settingP = let f s p = symbol s *> p in
-  (lexeme . choice . map try $
-    [ SIToken      <$> f "input"         itokenP
-    , SOToken      <$> f "output"        otokenP
-    , SCmpSeq      <$> f "cmp-seq"       buttonP
-    , SFallThrough <$> f "fallthrough"   bool
-    , SAllowCmd    <$> f "allow-cmd"     bool
-    , SCmpSeqDelay <$> f "cmp-seq-delay" numP
-    , SKeySeqDelay <$> f "key-seq-delay" numP
-    , SImplArnd    <$> f "implicit-around" implArndP
-    ])
+settingP =
+  choice
+    [ SIToken      <$> sexpr "input"         itokenP
+    , SOToken      <$> sexpr "output"        otokenP
+    , SCmpSeq      <$> sexpr "cmp-seq"       buttonP
+    , SFallThrough <$> sexpr "fallthrough"   boolP
+    , SAllowCmd    <$> sexpr "allow-cmd"     boolP
+    , SCmpSeqDelay <$> sexpr "cmp-seq-delay" numP
+    , SKeySeqDelay <$> sexpr "key-seq-delay" numP
+    , SImplArnd    <$> sexpr "implicit-around" implArndP
+    ]
 
 --------------------------------------------------------------------------------
 -- $defalias
 
 -- | Parse a collection of names and buttons
 defaliasP :: Parser DefAlias
-defaliasP = many $ (,) <$> lexeme word <*> buttonP
+defaliasP = many $ (,) <$> word <*> buttonP
 
 --------------------------------------------------------------------------------
 -- $defsrc
@@ -392,19 +393,19 @@ defaliasP = many $ (,) <$> lexeme word <*> buttonP
 defsrcP :: Parser DefSrc
 defsrcP =
   DefSrc
-    <$> optional (keywordP "name" word)
-    <*> many (lexeme keycodeP)
+    <$> optarg'P "name" word
+    <*> many keycodeP
 
 --------------------------------------------------------------------------------
 -- $deflayer
 
 deflayerP :: Parser DefLayer
-deflayerP = DefLayer <$> lexeme word <*> many (lexeme layerSettingP)
+deflayerP = DefLayer <$> word <*> many layerSettingP
 
 layerSettingP :: Parser DefLayerSetting
 layerSettingP =
-  lexeme . choice . map try $
-    [ LSrcName <$> keywordP "source" word
-    , LImplArnd <$> keywordP "implicit-around" implArndP
-    , LButton <$> buttonP
+  choice
+    [ LSrcName   <$> optargP "source" word
+    , LImplArnd  <$> optargP "implicit-around" implArndP
+    , LButton    <$> buttonP
     ]

--- a/test/KMonad/ComposeSeqSpec.hs
+++ b/test/KMonad/ComposeSeqSpec.hs
@@ -26,7 +26,7 @@ spec = describe "compose-sequences" $ do
   checkComposeSeq (expected, c, name) = describe ("Compose sequence for " <> unpack name) $ do
     let c' = T.singleton c
     let actualSeq = runParser buttonP "" c'
-    let expectedSeq = runParser (KComposeSeq <$> some buttonP) "" expected
+    let expectedSeq = runParser (KComposeSeq <$> some buttonP <* eof) "" expected
     let actualE2E = parseTokens $ "(deflayer <test> " <> c' <> " )"
     let expectedE2E = first ParseError expectedSeq <&> \x -> [KDefLayer (DefLayer "<test>" [LButton x])]
     it "Is compose sequence" $ actualSeq `shouldSatisfy` parsesAsValidComposeSeq


### PR DESCRIPTION
This should not break any existing configs, and improve the error messages somewhat.
The messages are still not perfect, as we don't do a separate tokenizing step
(which is very hard, since `"` is either the start of a string or a button,
depending of the context).
This should also reduce the duplicate `lexeme`s sometimes found, and make the code
less confusing in regards to when to use them.
Furthermore it is more robust, i.e. less order dependence of parsing
branches, and less back tracking, as `try` is only applied when we
really need it.
We let the primitives do `lexeme`, and therefore (mostly) don't need any in other functions.
Furthermore we use `terminated` instead of `lexeme`, since this ensures we don't put
keywords next to each other (see the downsides below).
Technically sometimes a `lexeme` is missing if the token doesn't parse anything.
This can happen due to an empty `many` or an `option`. In this case the `lexeme`
is covered by the previous token.

I have tested this against `tutorial.kbd`, my personal config and `kmonad-contrib`.
There were only errors in:
- nharward's config, since no `defcfg` blocks are defined
- `david-janssen/neo-test.kbd`, since this uses unknown compose sequences and has been
  broken since at least 0.4.0.

The downside is, that my favourite config broke:
```
(defcfgcmp-seqS-+~input(device-file"")cmp-seqP0output(uinput-sink""))
(defsrc-)
(deflayer(;; (around-"))
```