### PR TITLE
Fixed `list-keyboards` on old macos versions

### DIFF
--- a/c_src/mac/list-keyboards.c
+++ b/c_src/mac/list-keyboards.c
@@ -1,6 +1,12 @@
 #include <IOKit/hid/IOHIDLib.h>
 #include <IOKit/hidsystem/IOHIDShared.h>
 
+/* The name was changed from "Master" to "Main" in Apple SDK 12.0 (Monterey) */
+/* MAC_OS_X_VERSION_12_0 does not exist :( */
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 120000
+    #define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 int main() {
     CFMutableDictionaryRef matching_dictionary = IOServiceMatching(kIOHIDDeviceKey);
     if(!matching_dictionary) {

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### Fixed
 
 - Fixed excessive backtracking in the parser leading to unreadable errors (#985)
+- Fixed the `c_src/mac/list-keyboards.c` on Apple SDK < 12.0 (#987)
 
 ## 0.4.4 – 2025-04-11
 


### PR DESCRIPTION
Should fix #986