### PR TITLE
Update documentation for Docker install instructions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -274,7 +274,8 @@ docker build -t kmonad-builder -f ci/Dockerfile.linux .
 # Spin up an ephemeral Docker container from the built image, to just copy the
 # built binary to the host's current directory bind-mounted inside the
 # container at /host/.
-docker run --rm -it -v ${PWD}:/host/ kmonad-builder bash -c 'cp -vp /root/.local/bin/kmonad /host/'
+mkdir output
+docker run --rm -v ${PWD}/output:/host/ kmonad-builder bash -c 'cp -vp /output/* /host/'
 
 # Clean up build image, since it is no longer needed.
 docker rmi kmonad-builder


### PR DESCRIPTION
### Description

Small adjustment to documentation to correct the path of the binary output of the Docker container. The path had changed when the Windows Dockerfile was added (51b32e2). 

### Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/kmonad/kmonad/blob/master/CONTRIBUTING.md)
- [x] I've also appended my changes to the `CHANGELOG.md` if applicable
