### PR TITLE
tutorial: Note that a broken kmonad does not break other keyboards

### DIFF
--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -734,7 +734,7 @@
   switch into a layer that you can never get out of. Or worse, you could
   theoretically have a layer full of only `XX`s and switch into that, rendering
   your keyboard unusable until you somehow manage to kill KMonad (without using
-  your keyboard).
+  this keyboard).
 
   However, when handled well, `layer-switch` is very useful, letting you switch
   between 'modes' for your keyboard. I have a tiny keyboard with a weird keymap,


### PR DESCRIPTION
One word change.

On all suported platforms, Kmonad processes [initiate bound](https://github.com/kmonad/kmonad/blob/master/doc/quick-reference.md#input-and-output) to capture input from a specific keyboard, so when the process gets to an unusable state only the process' keyboard is affected (except on Windows).

### Description

Include a description for your changes, including the motivation behind them.

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/kmonad/kmonad/blob/master/CONTRIBUTING.md)
- [X] I've also appended my changes to the `CHANGELOG.md` if applicable
