### PR TITLE
tutorial: Note you could kill kmonad with other keyboards

### DIFF
--- a/keymap/tutorial.kbd
+++ b/keymap/tutorial.kbd
@@ -733,8 +733,8 @@
   an unusable state until a restart has occurred). It is perfectly possible to
   switch into a layer that you can never get out of. Or worse, you could
   theoretically have a layer full of only `XX`s and switch into that, rendering
-  your keyboard unusable until you somehow manage to kill KMonad (without using
-  your keyboard).
+  the configured keyboard unusable until you somehow manage to kill KMonad
+  (without using said keyboard).
 
   However, when handled well, `layer-switch` is very useful, letting you switch
   between 'modes' for your keyboard. I have a tiny keyboard with a weird keymap,


### PR DESCRIPTION
### Description

A small wording tweak.

Usually kmonad has been configured by the user to be bound to capture input from a specific keyboard, so when the process gets to an unusable state only the process' keyboard is affected.

Based on #996.
### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/kmonad/kmonad/blob/master/CONTRIBUTING.md)
- [X] I've also appended my changes to the `CHANGELOG.md` if applicable
