### PR TITLE
Hacky fix for #530

### DIFF
--- a/src/KMonad/Keyboard/IO/Windows/Types.hs
+++ b/src/KMonad/Keyboard/IO/Windows/Types.hs
@@ -156,9 +156,9 @@ winCodeKeyCodeMapping =
   , (0x0C, KeyDelete)      -- Defined as VK_CLEAR
   , (0x0D, KeyEnter)
   , (0x0D, KeyKpEnter)
-  , (0x10, KeyLeftShift)   -- No 'sidedness'??
-  , (0x11, KeyLeftCtrl)    -- No 'sidedness'??
-  , (0x12, KeyLeftAlt)     -- No 'sidedness'??
+  , (0x10, Missing254)     -- Shift without sidedness. Only press event no release event, so we ignore it. (see #530)
+  , (0x11, Missing254)     -- Ctrl without sidedness. Only press event no release event, so we ignore it. (see #530)
+  , (0x12, Missing254)     -- Alt without sidedness. Only press event no release event, so we ignore it. (see #530)
   , (0x13, KeyPause)
   , (0x14, KeyCapsLock)
   , (0x15, KeyKatakana)
@@ -342,4 +342,5 @@ winCodeKeyCodeMapping =
   -- , (0xFC, ???)             -- Defined as VK_NONAME
   -- , (0xFD, ???)             -- Defined as VK_PA1
   -- , (0xFE, KeyDelete)       -- Defined as VK_OEM_CLEAR
+  , (0x00, Missing254)         -- HACK: We use `Missing254` to ignore keypresses
   ]

--- a/src/KMonad/Keyboard/IO/Windows/Types.hs
+++ b/src/KMonad/Keyboard/IO/Windows/Types.hs
@@ -29,9 +29,7 @@ import KMonad.Keyboard
 
 import Data.Tuple (swap)
 import qualified RIO.HashMap as M
-import qualified RIO.NonEmpty as NE (groupAllWith)
--- TODO: use `Data.Foldable1` instead when `base` >= 4.18.0.0
-import qualified Data.Foldable as NE (minimumBy, maximumBy)
+import qualified RIO.NonEmpty as NE (groupAllWith, head, last)
 
 ----------------------------------------------------------------------------
 -- $err
@@ -128,7 +126,7 @@ fromWinKeyEvent (WinKeyEvent (s, c)) = case fromWinKeycode c of
 -- FIXME: There are loads of missing correspondences, mostly for rare-keys. How
 -- do these line up? Ideally this mapping would be total.
 winCodeToKeyCode :: M.HashMap WinKeycode Keycode
-winCodeToKeyCode = M.fromList $ NE.minimumBy (compare `on` snd) <$> NE.groupAllWith fst winCodeKeyCodeMapping
+winCodeToKeyCode = M.fromList $ NE.head <$> NE.groupAllWith fst winCodeKeyCodeMapping
 
 -- | Translate a KMonad KeyCode to the corresponding Windows virtual-key code
 --
@@ -136,7 +134,7 @@ winCodeToKeyCode = M.fromList $ NE.minimumBy (compare `on` snd) <$> NE.groupAllW
 -- there will be duplicates where more than one virtual-key code produces the
 -- same KMonad KeyCode. See https://github.com/kmonad/kmonad/issues/326
 keyCodeToWinCode :: M.HashMap Keycode WinKeycode
-keyCodeToWinCode = M.fromList $ swap . NE.maximumBy (compare `on` fst) <$> NE.groupAllWith snd winCodeKeyCodeMapping
+keyCodeToWinCode = M.fromList $ swap . NE.last <$> NE.groupAllWith snd winCodeKeyCodeMapping
 
 -- | A table of which virtual-key code from Windows
 -- correspond to which KMonad KeyCode.


### PR DESCRIPTION
We ignore the modifiers without sideness hopefully this doesn't break anything.
Using `Missing254` as an ignore this key is quite hacky, but arguably this was already done before with `0x00`.
A better solution should be implemented if this solution actually works.
But hopefully this fixes #530.