### PR TITLE
Fix nested implicit arounds in tap-macros

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed excessive backtracking in the parser leading to unreadable errors (#985)
 - Fixed the `c_src/mac/list-keyboards.c` on Apple SDK < 12.0 (#987)
 - Fixed random crash on startup on windows. (#1005)
+- Nested `implicit-around`s in `tap-macro`s are inconsistent. (#1012)
 
 ## 0.4.4 – 2025-04-11
 

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -209,9 +209,12 @@ around ::
      Button -- ^ The outer 'Button'
   -> Button -- ^ The inner 'Button'
   -> Button -- ^ The resulting nested 'Button'
-around outer inner = mkButton
+around outer inner = mkButton'
   (runAction (outer^.pressAction)   *> runAction (inner^.pressAction))
   (runAction (inner^.releaseAction) *> runAction (outer^.releaseAction))
+  $ runAction (outer^.pressAction)
+  *> runAction (inner^.tapAction)
+  *> runAction (outer^.releaseAction)
 
 -- | A variant of `around`, which releases its outer button when another key
 -- is pressed.


### PR DESCRIPTION
The hack of providing an overwrite on tap does not propogate through the overridden around.
So we supply a custom `tap` action for `around`.