### PR TITLE
Partially fix `sticky-key` tapping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 - Fixed excessive backtracking in the parser leading to unreadable errors (#985)
 - Fixed the `c_src/mac/list-keyboards.c` on Apple SDK < 12.0 (#987)
 - Fixed random crash on startup on windows. (#1005)
+- Fixed `sticky-key` as tap in `tap-hold` style buttons. (#1014)
 
 ## 0.4.4 – 2025-04-11
 

--- a/src/KMonad/Model/Button.hs
+++ b/src/KMonad/Model/Button.hs
@@ -594,7 +594,7 @@ layerNext t = onPress $ do
 -- pressed for the button after it if that button was pressed in the
 -- given timeframe.
 stickyKey :: Milliseconds -> Button -> Button
-stickyKey ms b = onPress go
+stickyKey ms b = mkButton' go (pure ()) doTap
  where
   go :: MonadK m => m ()
   go = hookF InputHook $ \e -> do


### PR DESCRIPTION
This does not fix `sticky-key` tapping in general as that is probably impossible without a better internal model.
Atleast it fixes the stuck on wait for release part.
