### PR TITLE
Udev needs groups to be system groups to allow adding them

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ## Unreleased
 
+### Breaking
+
+- With systemd v258 udevd ignores `GROUP=` setting with a non-system group.
+  If you followed the [FAQ entry: How do I get Uinput permissions?](doc/faq.md#q-how-do-i-get-uinput-permissions)
+  and created the `uinput` group delete the group (`sudo groupdel uinput`)
+  and create a new group with the user added to it (see FAQ entry).
+
+
 ### Added
 
 - `XX` may be used in `defsrc` as a placeholder button.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -40,7 +40,7 @@ If the `uinput` group does not exist, create a new group with:
 1. Make sure the `uinput` group exists
 
 ``` shell
-sudo groupadd uinput
+sudo groupadd --system uinput
 ```
 
 2. Add your user to the `input` and the `uinput` group:


### PR DESCRIPTION
Fixes #1020.

Thanks @mashtonian.

@slotThe should this be mentioned in the changelog? It's not a change in KMonad but in the install instructions.
Though it may still result in breakage for users updating systemd.

Furthermore I'm unsure how to fix the nixos module. Should we hardcode a gid?