### PR TITLE
Add support for FreeBSD

### DIFF
--- a/c_src/keyio.c
+++ b/c_src/keyio.c
@@ -3,8 +3,13 @@
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
+#if __linux__
 #include <linux/input.h>
 #include <linux/uinput.h>
+#elif __FreeBSD__
+#include <dev/evdev/input.h>
+#include <dev/evdev/uinput.h>
+#endif
 #include <fcntl.h>
 
 // Perform an IOCTL grab or release on an open keyboard handle

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
   Buttons binded to it will never trigger. (#992)
 - Using `:ignore-missing` in `device-file` you can wait for the device to be
   connected before starting and allow reconnecting in case of disconnect. (#1017)
+- Added support for FreeBSD
 
 ### Changed
 

--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -116,7 +116,7 @@ library
       KMonad.Util.MultiMap
       Paths_kmonad
 
-  if os(linux)
+  if os(linux) || os(freebsd)
     exposed-modules:
       KMonad.Keyboard.IO.Linux.DeviceSource
       KMonad.Keyboard.IO.Linux.UinputSink

--- a/src/KMonad/Args/Joiner.hs
+++ b/src/KMonad/Args/Joiner.hs
@@ -34,7 +34,7 @@ import KMonad.Model.Button
 import KMonad.Keyboard
 import KMonad.Keyboard.IO
 
-#ifdef linux_HOST_OS
+#if defined(linux_HOST_OS) || defined(freebsd_HOST_OS)
 import KMonad.Keyboard.IO.Linux.DeviceSource
 import KMonad.Keyboard.IO.Linux.UinputSink
 #endif
@@ -286,7 +286,7 @@ getKeySeqDelay = do
     Left None      -> pure (Just 1)
     Left Duplicate -> throwError $ DuplicateSetting "key-seq-delay"
 
-#ifdef linux_HOST_OS
+#if defined(linux_HOST_OS) || defined(freebsd_HOST_OS)
 
 -- | The Linux correspondence between IToken and actual code
 pickInput :: IToken -> J (LogFunc -> IO (Acquire KeySource))


### PR DESCRIPTION
### Description

This change adds support for FreeBSD. The change is rather straightforward as FreeBSD also supports uinput and evdev, hence it mostly just requires adding the appropriate `ifdef`s and a slight change in include paths.

Currently daily driving it on my laptops without any issues.

### Checklist

- [X] I've read [CONTRIBUTING.md](https://github.com/kmonad/kmonad/blob/master/CONTRIBUTING.md)
- [X] I've also appended my changes to the `CHANGELOG.md` if applicable
