### PR TITLE
WIP: Implement Coaround fixing Copilot key not mappable

### DIFF
--- a/kmonad.cabal
+++ b/kmonad.cabal
@@ -54,6 +54,7 @@ library
     , unliftio
     , template-haskell
   default-extensions:
+      BangPatterns
       ConstraintKinds
       DeriveFunctor
       DeriveGeneric
@@ -70,6 +71,7 @@ library
       NamedFieldPuns
       NoImplicitPrelude
       OverloadedStrings
+      PatternSynonyms
       RankNTypes
       TemplateHaskell
       TupleSections
@@ -93,6 +95,7 @@ library
       KMonad.Model.Action
       KMonad.Model.BEnv
       KMonad.Model.Button
+      KMonad.Model.Coaround
       KMonad.Model.Dispatch
       KMonad.Model.EventSrc
       KMonad.Model.Hooks

--- a/src/KMonad/App/Main.hs
+++ b/src/KMonad/App/Main.hs
@@ -26,6 +26,7 @@ import KMonad.Model
 
 
 import KMonad.Model.EventSrc
+import qualified KMonad.Model.Coaround as Ca
 import qualified KMonad.Model.Dispatch as Dp
 import qualified KMonad.Model.Hooks    as Hs
 import qualified KMonad.Model.Sluice   as Sl
@@ -85,7 +86,9 @@ initAppEnv cfg = do
   src <- using $ cfg^.keySourceDev
 
   -- Initialize the pull-chain components
-  dsp <- Dp.mkDispatch =<< pullToESrc "receiver_proc" (awaitKey src)
+  let cas = [Ca.CoaroundKey KeyCopilot $ KeyLeftMeta :| [KeyLeftShift, KeyF23]]
+  ca  <- Ca.mkCoaround 2 cas =<< pullToESrc "receiver_proc" (awaitKey src)
+  dsp <- Dp.mkDispatch $ Ca.pull  ca
   ihk <- Hs.mkHooks    $ Dp.pull  dsp
   slc <- Sl.mkSluice   $ Hs.pull  ihk
 

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -823,6 +823,8 @@ data Keycode
   | VKXButton1
   | VKXButton2
   | VKOEM8 -- Does not exist on US keyboards
+  -- Weird keys implemented via hardware around
+  | KeyCopilot
   deriving (Eq, Show, Bounded, Enum, Ord, Typeable, Data)
 
 -- We manually define the Hashable instance, since we would need a `Generic`

--- a/src/KMonad/Keyboard/Types.hs
+++ b/src/KMonad/Keyboard/Types.hs
@@ -2,7 +2,7 @@
 module KMonad.Keyboard.Types
   (
     Switch(..)
-  , KeyEvent
+  , KeyEvent(..)
   , mkKeyEvent
   , HasKeyEvent(..)
   , KeyPred

--- a/src/KMonad/Model/Coaround.hs
+++ b/src/KMonad/Model/Coaround.hs
@@ -1,0 +1,127 @@
+{-
+
+The 'Coaround' component solves the Problem of Keyboard firmware implementing tap-macros.
+We want to remap physical keys. So if a key press results in multiple actions we catch those
+and emit a single press / release event.
+
+Those keys need to be configured.
+
+-}
+module KMonad.Model.Coaround
+  ( Coaround
+  , CoaroundKey(..)
+  , mkCoaround
+  , pull
+  )
+where
+
+import KMonad.Prelude
+import KMonad.Util
+import KMonad.Keyboard
+import KMonad.Model.EventSrc
+
+import Data.Unique
+
+import RIO.Seq (Seq(..), (><))
+import qualified RIO.Seq  as Seq
+import qualified RIO.NonEmpty as N
+import qualified RIO.HashMap as M
+
+data CoaroundKey = CoaroundKey Keycode (NonEmpty Keycode)
+
+data Coaround = Coaround
+  { eventSrc :: EventSrc IO -- ^ Where we get our 'KeyEvent's from
+  , _coarounds :: [CoaroundKey] -- ^ All recognized coaround keys. No sequence should be a prefix of another
+  , _coaroundLasts :: HashMap Keycode Keycode -- ^ A map to map the key release based on the last entry in coarounds
+  , _codelay :: Milliseconds -- ^ How much time may pass between two keys which are part of the same coaroundkey
+  , _blockedKCs :: IORef (Seq Keycode) -- ^ Blocked keycodes which may be part of a coaround key
+  , _rerunKCs :: TVar (Seq Keycode) -- ^ Previously blocked keycodes which need to be rerun
+  , _inProcessCAs :: IORef [CoaroundKey] -- ^ Internal state of possible continuations of a coaround sequence
+  , _injectTmr  :: TMVar Unique  -- ^ Used to signal timeouts
+  , _pendingTmr :: TVar Unique
+  }
+makeLenses ''Coaround
+
+mkCoaround' :: MonadUnliftIO m => Milliseconds -> [CoaroundKey] -> EventSrc m -> m Coaround
+mkCoaround' cd cas s = withRunInIO $ \u -> do
+  let cals = M.fromList $ cas <&> \(CoaroundKey r seq) -> (N.last seq, r)
+  buf <- newIORef mempty
+  rerun <- newTVarIO mempty
+  ipcas <- newIORef []
+  itr <- newEmptyTMVarIO
+  pending <- newTVarIO =<< newUnique
+  pure $ Coaround (unliftESrc u s) cas cals cd buf rerun ipcas itr pending
+
+mkCoaround :: MonadUnliftIO m => Milliseconds -> [CoaroundKey] -> EventSrc m -> ContT r m Coaround
+mkCoaround cd cas = lift . mkCoaround' cd cas
+
+advance :: Keycode -> [CoaroundKey] -> Either [CoaroundKey] Keycode
+advance _ [] = Left []
+advance kc (CoaroundKey r (kc' :| rest) : cas)
+  | kc == kc' = case rest of
+    [] -> Right r -- This coaround completed. Emit
+    (x : xs) -> case advance kc cas of
+      Right r' -> Right r' -- Other coaround completed
+      Left cas' -> Left $ CoaroundKey r (x :| xs) : cas'
+advance kc (CoaroundKey _ (_ :| []) : cas) = advance kc cas -- This sequence does not match
+advance kc (CoaroundKey r (_ :| x : xs) : cas) = -- Skip current entry in the sequence
+  advance kc (CoaroundKey r (x :| xs) : cas)
+
+step :: HasLogFunc e => Coaround -> KeyEvent -> RIO e (Maybe KeyEvent)
+step c (KeyEvent Press kc) = do
+  cas <- readIORef (c^.inProcessCAs) <&> \case
+    [] -> c^.coarounds
+    cas -> cas
+
+  case advance kc cas of
+    -- Not a CA at index 0 in blockedKEs
+    -- It could still contain another start of a sequence
+    -- requiring unblocking them individually.
+    -- We ignore this edge case for now
+    Left [] -> do
+      writeIORef (c^.inProcessCAs) []
+      blocked <- readIORef (c^.blockedKCs)
+      atomically $ modifyTVar (c^.rerunKCs) (>< (blocked |> kc))
+      writeIORef (c^.blockedKCs) mempty
+      pure Nothing
+    Left cas' -> do
+      writeIORef (c^.inProcessCAs) cas'
+      modifyIORef (c^.blockedKCs) (|> kc)
+      tag <- liftIO newUnique
+      atomically $ writeTVar (c^.pendingTmr) tag
+      void . async $ do
+        threadDelay $ 1000 * fromIntegral (c^.codelay)
+        atomically $ putTMVar (c^.injectTmr)  tag
+      pure Nothing
+    Right rkc -> do
+      writeIORef (c^.inProcessCAs) []
+      writeIORef (c^.blockedKCs) mempty
+      pure $ Just (KeyEvent Press rkc)
+step c ke@(KeyEvent Release kc) = case M.lookup kc (c^.coaroundLasts) of
+  Just r -> pure $ Just (KeyEvent Release r)
+  Nothing -> pure $ Just ke
+
+pull :: (HasLogFunc e)
+  => Coaround
+  -> EventSrc (RIO e)
+pull c@Coaround{eventSrc = EventSrc{tryESrc, postESrc}} = EventSrc
+  { tryESrc = (Left . Left <$> tryRerun) `orElse` (Left . Right <$> takeTMVar (c^.injectTmr)) `orElse` (Right <$> tryESrc)
+  , postESrc = \case
+    Left (Left kc) -> pure $ Just (KeyEvent Press kc)
+    Left (Right t) -> runTimeout t $> Nothing
+    Right e -> liftIO (postESrc e) >>= maybe (pure Nothing) (step c) -- We caught a real event
+  }
+ where
+  tryRerun = do
+    rerun <- readTVar (c^.rerunKCs)
+    case rerun of
+      Seq.Empty -> retrySTM
+      (kc :<| rerun') -> kc <$ writeTVar (c^.rerunKCs) rerun'
+  runTimeout t = do
+    t' <- atomically $ readTVar (c^.pendingTmr)
+    if t /= t' then pure ()
+    else do
+      writeIORef (c^.inProcessCAs) []
+      blocked <- readIORef (c^.blockedKCs)
+      atomically $ modifyTVar (c^.rerunKCs) (>< blocked)
+      writeIORef (c^.blockedKCs) mempty


### PR DESCRIPTION
A ruth sketch of an implementation. It should mostly work.

Problems:
1. Effectively tries to duplicate Sluice, Dispatch, Hooks in one component (use existing ones)
2. trying to press sft / met + copilot simultaniously causes problems (if it results in `Psft Pmet Pf23`, `Psft Pmet Pcopilot` instead of `Psft Pcopilot` is handled)
3. Always on. Even for users not having those keys (should have some opt-in `defkeys`? part in the config)
4. Requires lots of warnings on edge cases + documentation in general.
5. `copilot` without config option should be an error / warning.
6. `copilot` should not be allowed in `deflayer` (?)

Eventhough this would already fix #931 but 1, 3 and 4 would need some addressing first.
@AlejandroMinaya could you test whether it is handled properly. As said before some modifiers may cause issues.
Please list such cases
