### PR TITLE
Add macOS Do Not Disturb key support

### DIFF
--- a/c_src/mac/dext.cpp
+++ b/c_src/mac/dext.cpp
@@ -15,6 +15,7 @@ static pqrs::karabiner::driverkit::virtual_hid_device_driver::hid_report::keyboa
 static pqrs::karabiner::driverkit::virtual_hid_device_driver::hid_report::apple_vendor_top_case_input top_case;
 static pqrs::karabiner::driverkit::virtual_hid_device_driver::hid_report::apple_vendor_keyboard_input apple_keyboard;
 static pqrs::karabiner::driverkit::virtual_hid_device_driver::hid_report::consumer_input consumer;
+static pqrs::karabiner::driverkit::virtual_hid_device_driver::hid_report::generic_desktop_input generic_desktop;
 
 int init_sink() {
     pqrs::dispatcher::extra::initialize_shared_dispatcher();
@@ -92,6 +93,8 @@ extern "C" int send_key(struct KeyEvent *e) {
         return send_key(apple_keyboard, e);
     else if(usage_page == pqrs::hid::usage_page::consumer)
         return send_key(consumer, e);
+    else if(usage_page == pqrs::hid::usage_page::generic_desktop)
+        return send_key(generic_desktop, e);
     else
         return 1;
 }

--- a/c_src/mac/kext.cpp
+++ b/c_src/mac/kext.cpp
@@ -13,6 +13,7 @@ static pqrs::karabiner_virtual_hid_device::hid_report::keyboard_input keyboard;
 static pqrs::karabiner_virtual_hid_device::hid_report::apple_vendor_top_case_input top_case;
 static pqrs::karabiner_virtual_hid_device::hid_report::apple_vendor_keyboard_input apple_keyboard;
 static pqrs::karabiner_virtual_hid_device::hid_report::consumer_input consumer;
+static pqrs::karabiner_virtual_hid_device::hid_report::consumer_input generic_desktop;
 
 int exit_sink() {
     int retval = 0;
@@ -112,6 +113,8 @@ extern "C" int send_key(struct KeyEvent *e) {
         return send_key(apple_keyboard, e);
     else if(usage_page == pqrs::karabiner_virtual_hid_device::usage_page::consumer)
         return send_key(consumer, e);
+    else if(usage_page == pqrs::karabiner_virtual_hid_device::usage_page::generic_desktop)
+        return send_key(generic_desktop, e);
     else
         return 1;
 }

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 ### Added
 
 - Added macOS HID mapping for Do Not Disturb key on Apple Silicon Mac keyboards (MacBook Pro 14"/16" 2021+, MacBook Air M2+, Magic Keyboard with Touch ID)
+- Added `dnd` alias for the do not disturb key
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0)
 
 ### Added
 
+- Added macOS HID mapping for Do Not Disturb key on Apple Silicon Mac keyboards (MacBook Pro 14"/16" 2021+, MacBook Air M2+, Magic Keyboard with Touch ID)
+
 ### Changed
 
 ### Fixed

--- a/src/KMonad/Keyboard/IO/Mac/Types.hs
+++ b/src/KMonad/Keyboard/IO/Mac/Types.hs
@@ -690,4 +690,5 @@ kcMapRaw =
   , ((0xFF01,0x1), KeySpotlight)
   , ((0xFF01,0x4), KeyLaunchpad)
   , ((0xFF01,0x10), KeyMissionCtrl)
+  , ((0x1,0x9B),   KeyDoNotDisturb)
   ]

--- a/src/KMonad/Keyboard/IO/Mac/Types.hs
+++ b/src/KMonad/Keyboard/IO/Mac/Types.hs
@@ -127,7 +127,8 @@ kcMap = M.fromList kcMapRaw
 
 kcMapRaw :: [(MacKeycode, Keycode)]
 kcMapRaw =
-  [ ((0x7,0x4), KeyA)
+  [ ((0x1,0x9B), KeyDoNotDisturb)
+  , ((0x7,0x4), KeyA)
   , ((0x7,0x5), KeyB)
   , ((0x7,0x6), KeyC)
   , ((0x7,0x7), KeyD)
@@ -690,5 +691,4 @@ kcMapRaw =
   , ((0xFF01,0x1), KeySpotlight)
   , ((0xFF01,0x4), KeyLaunchpad)
   , ((0xFF01,0x10), KeyMissionCtrl)
-  , ((0x1,0x9B),   KeyDoNotDisturb)
   ]

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -935,6 +935,7 @@ aliases = Q.mkMultiMap
   , (KeyMissionCtrl,      ["mctl"])
   , (KeySpotlight,        ["spot"])
   , (KeyDictation,        ["dict"])
+  , (KeyDoNotDisturb,     ["dnd"])
   -- Japanese
   , (KeyZenkakuHankaku,   ["zeh"])
   , (KeyMuhenkan,         ["muh"])

--- a/src/KMonad/Keyboard/Keycode.hs
+++ b/src/KMonad/Keyboard/Keycode.hs
@@ -930,12 +930,12 @@ aliases = Q.mkMultiMap
   , (KeyPreviousSong,     ["prev"])
   , (KeyMicmute,          ["micm"])
   , (KeyCoffee,           ["lock"])
+  , (KeyDoNotDisturb,     ["dnd"])
   -- Darwin
   , (KeyLaunchpad,        ["lp"])
   , (KeyMissionCtrl,      ["mctl"])
   , (KeySpotlight,        ["spot"])
   , (KeyDictation,        ["dict"])
-  , (KeyDoNotDisturb,     ["dnd"])
   -- Japanese
   , (KeyZenkakuHankaku,   ["zeh"])
   , (KeyMuhenkan,         ["muh"])


### PR DESCRIPTION
## Summary

- Add `dnd` alias and macOS HID mapping `(0x01, 0x9B)` → `KeyDoNotDisturb` for emitting the system Do Not Disturb / Focus toggle
- Route Generic Desktop (`0x01`) keys through the dext output sink so `dnd` actually reaches macOS (previously dropped silently)
- Keep `kcMapRaw` sorted for existing keycode tests

## Background

On Apple Silicon Mac keyboards (MacBook Pro 14"/16" 2021+, MacBook Air M2+, Magic Keyboard with Touch ID), the physical Do Not Disturb key is in the F6 position. KMonad intercepts input before macOS translates it, so the key arrives as **`f6`** (`0x07 / 0x3F`).

To trigger the system action, KMonad must **emit** the standardized Generic Desktop code **`0x01 / 0x9B`** (`generic_desktop::do_not_disturb`). Unlike older Mac special keys (Mission Control, Spotlight, brightness), DND uses the standard HID page rather than Apple's proprietary `0xFF01` vendor page.

## Usage

```clojure
(defsrc
  ... f6 ...)

(deflayer default
  ... dnd ...)
```

Map `f6` → `dnd` to remap the physical key to the system DND toggle.

## Test plan

- [x] `stack test --flag kmonad:dext` passes (including sorted `kcMapRaw` check)
- [x] Built with `stack install --flag kmonad:dext` on macOS 26.x
- [x] Physical DND key received as `f6` in debug logs
- [x] Mapping `f6` → `dnd` toggles system Do Not Disturb / Focus